### PR TITLE
Add nl-BE locale

### DIFF
--- a/locales/all-locales
+++ b/locales/all-locales
@@ -2,6 +2,7 @@ ca
 cs
 de
 en-GB
+en-US
 es-ES
 nb-NO
 fi
@@ -9,6 +10,7 @@ fr
 it
 ja
 ja-JP-mac
+nl-BE
 pl
 pt-BR
 pt-PT

--- a/locales/nl-BE/ambassador-l10n.js
+++ b/locales/nl-BE/ambassador-l10n.js
@@ -1,0 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#filter substitution
+
+pref("general.useragent.locale", "nl-BE");

--- a/locales/nl-BE/chrome/about.dtd
+++ b/locales/nl-BE/chrome/about.dtd
@@ -1,0 +1,18 @@
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+
+<!ENTITY window.title  "Over Ambassador">
+
+<!ENTITY ambassador.label      "Ambassador">
+<!ENTITY version.unknown.label "Versie onbekend">
+<!ENTITY version.known.label   "Versie &#37;S">
+<!ENTITY description.label     "Een propere, eenvoudige en uiterst aanpasbare Internet Relay Chat (IRC)-client.">
+
+<!ENTITY homepage.label    "Bezoek de website">
+<!ENTITY copyversion.label "Kopieer versiegegevens">
+
+<!ENTITY section.uxp.label     "Omzetting naar UXP:">
+<!ENTITY section.orig.label    "Oorspronkelijk ontwikkelteam:">
+<!ENTITY section.locale.label  "Vertaling:">
+<!ENTITY section.contrib.label "Bijdragers:">

--- a/locales/nl-BE/chrome/ambassador.dtd
+++ b/locales/nl-BE/chrome/ambassador.dtd
@@ -1,0 +1,19 @@
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+
+<!ENTITY Menubar.tooltip    "Hoofdmenu">
+<!ENTITY Toolbar.tooltip    "Hoofdwerkbalk">
+
+
+<!ENTITY multiline-expand.tooltip   "Wissel naar invoer met meerdere lijnen (Ctrl+Up)">
+<!ENTITY multiline-contract.tooltip "Wissel naar invoer met enkele lijn (Ctrl+Down)">
+<!ENTITY multiline-send.tooltip     "Verstuur deze tekst (Ctrl+Enter)">
+<!ENTITY server-nick.tooltip        "Verander van nickname of zet je status op afwezig. Duw op Escape om het invoerveld te focussen.">
+
+<!ENTITY Underline.label             "Onderlijnen">
+<!ENTITY Bold.label                  "Vet">
+<!ENTITY Reverse.label               "Video terugspoelen">
+<!ENTITY Normal.label                "Normaal">
+<!ENTITY Color.label                 "Kleur">
+<!ENTITY ForeBack.label              "xx=Fore yy=Back">

--- a/locales/nl-BE/chrome/ambassador.properties
+++ b/locales/nl-BE/chrome/ambassador.properties
@@ -1,0 +1,1823 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+### Notes for localizers ###
+#
+# The following version number is the "localisation version number", and MUST
+# match the locale.version in the original locale this is based on. In other
+# words, if the locale.version in two files is the same, both files MUST have
+# exactly the same list of locale strings.
+#
+# If you always start with an en-US locale, and replace all strings, you can
+# leave this value alone. If you update your locale file based on changes in
+# the en-US locale, please remember to always update this in your locale to
+# match en-US when you're done.
+#
+# locale.error is the message is the message displayed to the user if the
+# locale version number does not match what Ambassador is expecting, and will
+# have the the following replacements:
+#
+#   %1$S   Ambassador version (e.g. "0.9.69").
+#   %2$S   Expected locale version (e.g. "0.9.69").
+#   %3$S   Locale being loaded (e.g. "fr-FR").
+#   %4$S   Actual locale version being (e.g. "0.9.68.2").
+#
+# In the example above, the user would be using Ambassador 0.9.69, which
+# expects a locale version of 0.9.69. It tried to use the fr-FR locale,
+# but found it was only version 0.9.68.3.
+#
+# Note: the Ambassador version and expected locale versions may not always be
+#       the same. For example, if only non-locale changes have been made, the
+#       expected locale version will stay the same. This is to make using
+#       localisations between versions easier.
+#
+### End of notes ###
+
+locale.version = 1.0.0
+locale.error = You are using Ambassador %1$S, which requires the locale version %2$S. The currently selected locale, %3$S, is version %4$S, and therefore there may be problems running Ambassador.\n\nIt is strongly advised that you update or remove the Ambassador locale in question.
+locale.authors = XXX REPLACE THIS VALUE WITH A SEMICOLON-SEPARATED LIST OF NAMES FOR YOUR LOCALIZATION TEAM XXX
+
+# Misc
+
+unknown=<unknown>
+none=<none>
+na=<n/a>
+
+# util.js
+
+msg.alert   = Alert
+msg.prompt  = Prompt
+msg.confirm = Confirm
+
+# command.js
+
+### Notes for localizers ###
+#
+# Ambassador uses cmd.<command name>.* to construct the command's help,
+# parameters and any UI labels. For the command to continue to function, the
+# *.params entries MUST NOT BE CHANGED. Hopefully in the future you will be
+# able to localize these items as well.
+#
+### DO NOT LOCALIZE THE *.params STRINGS ###
+#
+# Note also that, for every command, an accesskey may be specified:
+#   EITHER by prefixing the desired accesskey with "&" in the .label string,
+#   OR     by specifying a .accesskey string, which is useful if the desired
+#          accesskey does not occur in the label.
+#
+# The following are therefore equivalent:
+#    cmd.foo.label = &Foo
+# and
+#    cmd.foo.label = Foo
+#    cmd.foo.accesskey = F
+#
+#
+# All localised strings may contain certain entities for branding purposes.
+# The three standard brand entities (brandShortName, brandFullName, vendorName)
+# can all be used like this:
+#     foo.bar = Some text used in &brandFullName;!
+#
+### End of notes ###
+
+cmd.about.label = About Ambassador
+cmd.about.help  = Display information about this version of Ambassador.
+
+cmd.about-config.label = Advanced Configuration
+cmd.about-config.help  =
+cmd.add-ons.label      = Add-ons
+cmd.add-ons.help       =
+cmd.add-ons.key        = accel shift A
+
+cmd.alias.params = [<alias-name> [<command-list>]]
+cmd.alias.help   = Defines <alias-name> as an alias for the semicolon (';') delimited list of commands specified by <command-list>.  If <command-list> is a minus ('-') character, the alias will be removed; if omitted, the alias will be displayed. If <alias-name> is not provided, all aliases will be listed.
+
+cmd.attach.params = <irc-url>
+cmd.attach.help   = Attaches to the IRC URL specified by <irc-url>.  If you are already attached, the view for <irc-url> is made current.  If that view has been deleted, it is recreated.  You may omit the irc:// portion of the <irc-url>.  Examples are: /attach freenode, /attach freenode/ambassador, and /attach irc.freenode.net/diplobot,isnick.
+
+cmd.away.label  = Away (default)
+cmd.away.format = Away ($reason)
+cmd.away.params = [<reason>]
+cmd.away.help   = If <reason> is specified, sets you away with that message. Used without <reason>, you are marked away with a default message.
+
+cmd.back.label  = Back
+cmd.back.params =
+cmd.back.help   = Marks you as no longer away.
+
+cmd.ban.label  = Ban
+cmd.ban.format = Ban from $channelName
+cmd.ban.params = [<nickname>]
+cmd.ban.help   = Bans a single user, or mask of users, from the current channel. A user's nickname may be specified, or a proper host mask can be used. Used without a nickname or mask, shows the list of bans currently in effect.
+
+cmd.cancel.help = Cancels an /attach or /server command, or a file transfer.  Use /cancel on a network view when Ambassador is repeatedly trying to attach to a network that is not responding, to tell Ambassador to give up before the normal number of retries.  Use /cancel on a file transfer view to stop the transfer.
+
+cmd.certmgr.label       = Certificate Manager
+cmd.certmgr.help        =
+
+cmd.charset.params = [<new-charset>]
+cmd.charset.help   = Sets the character encoding mode for the current view to <new-charset>, or displays the current character encoding mode if <new-charset> is not provided.
+
+cmd.channel-motif.params = [<motif> [<channel>]]
+cmd.channel-motif.help   = Sets the CSS file used for the message tab for this specific channel.  <motif> can be a URL to a .css file, or the shortcut "dark" or "light".  If <motif> is a minus ('-') character, the motif will revert to the network motif.  If <channel> is not provided, the current channel will be assumed.  See the ChatZilla motifs page at <http://chatzilla.hacksrus.com/motifs/> for more information on how to style Ambassador.  See also |motif|.
+
+cmd.channel-pref.params = [<pref-name> [<pref-value>]]
+cmd.channel-pref.help    = Sets the value of the preference named <pref-name> to the value of <pref-value> on the current channel.  If <pref-value> is not provided, the current value of <pref-name> will be displayed.  If both <pref-name> and <pref-value> are omitted, all preferences will be displayed.  If <pref-value> is a minus ('-') character, then the preference will revert back to its default value.
+
+cmd.clear-view.label  = Cl&ear Tab
+cmd.clear-view.params = [<view>]
+cmd.clear-view.help = Clear the current view, discarding *all* content.
+cmd.clear-view.key = accel L
+
+cmd.client.help = Make the ``*client*'' view current.  If the ``*client*'' view has been deleted, it will be recreated.
+
+cmd.cmd-docommand.params = <cmd-name>
+cmd.cmd-docommand.help   =
+
+cmd.cmd-undo.label  = &Undo
+cmd.cmd-undo.key    = accel Z
+cmd.cmd-undo.params =
+cmd.cmd-undo.help   = Undoes the last change made to text in the input box.
+
+cmd.cmd-redo.label  = &Redo
+cmd.cmd-redo.key    = accel Y
+cmd.cmd-redo.params =
+cmd.cmd-redo.help   = Redoes the last change to the text in the input box which you undid.
+
+cmd.cmd-cut.label  = Cu&t
+cmd.cmd-cut.key    = accel X
+cmd.cmd-cut.params =
+cmd.cmd-cut.help   = Copies the currently-selected text to clipboard, and removes it from the source.
+
+cmd.cmd-copy.label  = &Copy
+cmd.cmd-copy.key    = accel C
+cmd.cmd-copy.params =
+cmd.cmd-copy.help   = Copies the currently-selected text to clipboard.
+
+cmd.cmd-paste.label  = &Paste
+cmd.cmd-paste.key    = accel V
+cmd.cmd-paste.params =
+cmd.cmd-paste.help   = Pastes the contents of clipboard.
+
+cmd.cmd-delete.label  = &Delete
+cmd.cmd-delete.key    = VK_DELETE
+cmd.cmd-delete.params =
+cmd.cmd-delete.help   = Deletes the current selection.
+
+cmd.cmd-selectall.label  = Select &All
+cmd.cmd-selectall.key    = accel A
+cmd.cmd-selectall.params =
+cmd.cmd-selectall.help   = Selects all the text in the current view.
+
+cmd.cmd-copy-link-url.label  = Copy Link Location
+cmd.cmd-copy-link-url.params = <url>
+cmd.cmd-copy-link-url.help   = Copies the URL of the current link to clipboard.
+
+cmd.cmd-mozilla-prefs.label  = &&brandShortName; Preferences…
+cmd.cmd-mozilla-prefs.params =
+cmd.cmd-mozilla-prefs.help   =
+
+cmd.cmd-prefs.label  = Pr&eferences…
+cmd.cmd-prefs.params =
+cmd.cmd-prefs.help   =
+
+cmd.cmd-ambassador-prefs.label  = Ambassador Pr&eferences…
+cmd.cmd-ambassador-prefs.params =
+cmd.cmd-ambassador-prefs.help   =
+
+cmd.cmd-ambassador-opts.label  = &Options…
+cmd.cmd-ambassador-opts.params =
+cmd.cmd-ambassador-opts.help   =
+
+cmd.commands.params = [<pattern>]
+cmd.commands.help   = Lists all command names matching <pattern>, or all command names if pattern is not specified.
+
+cmd.create-tab-for-view.params = <view>
+cmd.create-tab-for-view.help   =
+
+cmd.custom-away.label  = Away (custom)…
+cmd.custom-away.help   = Prompts for a custom away message and then sets you away using it. Use the |/away| command to specify an away message as part of the command.
+
+cmd.sync-font.help      = Synchronizes all views with their current font settings.
+cmd.sync-header.help    = Synchronizes all views with their current header display setting.
+cmd.sync-log.help       = Synchronizes all views with their current logging setting.
+cmd.sync-motif.help     = Synchronizes all views with their current motif setting.
+cmd.sync-timestamp.help = Synchronizes all views with their current timestamp display settings.
+cmd.sync-window.help    = Synchronizes all views with their current output window setting.
+
+cmd.ctcp.params = <target> <code> [<params>]
+cmd.ctcp.help   = Sends the CTCP code <code> to the target (user or channel) <target>.  If <params> are specified they are sent along as well.
+
+cmd.default-charset.params = [<new-charset>]
+cmd.default-charset.help   = Sets the global default character encoding mode to <new-charset>, or displays the current global default character encoding mode if <new-charset> is not provided.
+
+cmd.delayed.params = <delay> <rest>
+cmd.delayed.help   = After |delay| seconds, run the command specified in |rest|.
+
+cmd.describe.params = <target> <action>
+cmd.describe.help   = Performs an 'action' at the |target|, either a channel or a user.
+
+cmd.dcc-accept.params = [<nickname> [<type> [<file>]]]
+cmd.dcc-accept.help   = Accepts an incoming DCC Chat or Send offer. If a |nickname| is not specified, the last offer that arrived will be accepted (for security reasons, this will not work in the first 10 seconds after an offer is received). You can also use a regular expression for either <nickname> or <file>.
+
+cmd.dcc-accept-list.params =
+cmd.dcc-accept-list.help   = Displays the DCC auto-accept list for the current network.
+
+cmd.dcc-accept-list-add.params = <nickname>
+cmd.dcc-accept-list-add.help   = Add someone to your DCC auto-accept list for the current network.
+
+cmd.dcc-accept-list-remove.params = <nickname>
+cmd.dcc-accept-list-remove.help   = Remove someone from your DCC auto-accept list for the current network.
+
+cmd.dcc-chat.params = [<nickname>]
+cmd.dcc-chat.help   = Sends a DCC Chat offer to |nickname| on the current server. On a query view, |nickname| may be omitted to send the offer to the query view's user.
+cmd.dcc-chat.label  = Direct Chat
+
+cmd.dcc-close.format = Disconnect From $userName
+cmd.dcc-close.label  = &Disconnect
+cmd.dcc-close.params = [<nickname> [<type> [<file>]]]
+cmd.dcc-close.help   = Closes an existing DCC connection. |nickname| may be omitted if run from a DCC view, in which case the DCC connection for that view will be closed. |type| and |file| may be needed to identify the connection. You can also use a regular expression for either <nickname> or <file>.
+
+cmd.dcc-decline.params = [<nickname>]
+cmd.dcc-decline.help   = Declines an incoming DCC Chat or Send offer. If a |nickname| is not specified, the last offer that arrived will be declined. You can also use a regular expression for <nickname>.
+
+cmd.dcc-list.params = [<type>]
+cmd.dcc-list.help   = Lists the currently known about DCC offers and connections. This may be limited to just "chat" or "send" using the |type| parameter.
+
+cmd.dcc-send.params = [<nickname> [<file>]]
+cmd.dcc-send.help   = Offers a file to |nickname|. On a query view, |nickname| may be omitted to send the offer to the query view's user. A file may be specified directly by passing |file| or, if omitted, selected from a browse dialog.
+cmd.dcc-send.label  = Send File…
+
+cmd.dcc-show-file.params = <file>
+cmd.dcc-show-file.help   = Opens the folder containing the file you downloaded.
+
+cmd.delete-view.key    = accel W
+cmd.delete-view.label  = &Close Tab
+cmd.delete-view.params = [<view>]
+cmd.delete-view.help   = Clear the current view, discarding *all* content, and drop its icon from the tab strip. If a channel view is deleted this way, you also leave the channel.
+
+cmd.dehop.label  = Remove Half-operator Status
+cmd.dehop.params = <nickname> [<...>]
+cmd.dehop.help   = Removes half-operator status from <nickname> on current channel. Requires operator status.
+
+cmd.deop.label  = Remove Operator Status
+cmd.deop.params = <nickname> [<...>]
+cmd.deop.help   = Removes operator status from <nickname> on current channel. Requires operator status.
+
+cmd.desc.params = [<description>]
+cmd.desc.help   = Changes the 'ircname' line returned when someone performs a /whois on you.  You must specify this *before* connecting to the network. If you omit <description>, the current description is shown.
+
+cmd.devoice.label  = Remove Voice Status
+cmd.devoice.params = <nickname> [<...>]
+cmd.devoice.help   = Removes voice status from <nickname> on current channel. Requires operator (or half-operator) status.
+
+cmd.disconnect.format = Disconnect From $networkName
+cmd.disconnect.label  = &Disconnect
+cmd.disconnect.params = [<reason>]
+cmd.disconnect.help   = Disconnects from the server represented by the active view when the command is executed providing the reason <reason> or the default reason if <reason> is not specified.
+
+cmd.disconnect-all.label  = &Disconnect From All Networks
+cmd.disconnect-all.params = [<reason>]
+cmd.disconnect-all.key    = accel D
+cmd.disconnect-all.help   = Disconnects from all networks providing the reason <reason> or the default reason if <reason> is not specified.
+
+cmd.echo.params = <message>
+cmd.echo.help   = Displays <message> in the current view, but does not send it to the server.
+
+cmd.edit-networks.label = &Networks...
+cmd.edit-networks.help  = Opens the network editor, where you can edit the list of available networks and servers.
+
+cmd.enable-plugin.params = <plugin>
+cmd.enable-plugin.help   = Meant to be used to re-enable a plugin after calling |disable-plugin|, this command calls the plugin's enablePlugin function.  There are no guarantees that the plugin will properly enable itself.
+
+cmd.eval.params = <expression>
+cmd.eval.help   = Evaluates <expression> as JavaScript code.  Not for the faint of heart.
+
+cmd.evalsilent.params = <expression>
+cmd.evalsilent.help   = Identical to the /eval command, except the [EVAL-IN] and [EVAL-OUT] lines are not displayed.
+
+cmd.except.params = [<nickname>]
+cmd.except.help   = Excepts a user from channel bans. A user's nickname may be specified, or a proper host mask can be used. Used without a nickname or mask, shows the list of exceptions currently in effect.
+
+cmd.exit.label  = E&xit Ambassador
+cmd.exit.params = [<reason>]
+cmd.exit.help   = Disconnects from all active servers and networks,  providing the reason <reason>, or the default reason if <reason> is not specified.  Exits Ambassador after disconnecting.
+
+cmd.exit-mozilla.label = E&xit
+cmd.exit-mozilla.help  = Exit &brandShortName;.
+
+cmd.faq.label   = ChatZilla FAQ
+
+cmd.find.label  = &Find…
+cmd.find.key    = accel F
+cmd.find.params = [<rest>]
+cmd.find.help   = Finds text in the current view.
+
+cmd.find-again.label  = Find A&gain
+cmd.find-again.key    = accel G
+cmd.find-again.params =
+cmd.find-again.help   = Finds the next instance of your previously searched word.
+
+cmd.flush-ssl.label     = Flush SSL Cache
+cmd.flush-ssl.help      = Clears the SSL session cache. Not all IRC servers handle resuming SSL sessions cleanly, so it may be necessary to run this command manually if you are having trouble connecting to a server using SSL/TLS.
+
+cmd.focus-input.key  = VK_ESCAPE
+cmd.focus-input.help = Force keyboard focus to the input box.
+
+cmd.font-family.params = [<font>]
+cmd.font-family.help   = Sets or views the font family being used on the current view. Omit <font> to see the current font family. The value |default| will use your global font family, |serif|, |sans-serif| and |monospace| will use your global font settings, other values will set a font directly.
+
+cmd.font-family-default.label    = Default &Font
+cmd.font-family-serif.label      = Se&rif
+cmd.font-family-sans-serif.label = S&ans Serif
+cmd.font-family-monospace.label  = Mo&nospace
+
+cmd.font-family-other.format     = Other ($fontFamily)…
+cmd.font-family-other.label      = O&ther…
+cmd.font-family-other.help       = Prompts for a font family name.
+
+cmd.font-size.params = [<font-size>]
+cmd.font-size.help   = Sets or views the font size being used on the current view. Omit <font-size> to see the current font size. The size value is specified in points (pt). The value |default| will use your global font size, and the values |bigger| and |smaller| increase or reduce the size by a fixed amount each time.
+
+cmd.font-size-bigger.label  = Make Text &Bigger
+cmd.font-size-bigger.key    = accel +
+cmd.font-size-bigger2.key   = accel =
+cmd.font-size-smaller.label = Make Text &Smaller
+cmd.font-size-smaller.key   = accel -
+
+cmd.font-size-default.label = Default Si&ze
+cmd.font-size-small.label   = Sma&ll
+cmd.font-size-medium.label  = &Medium
+cmd.font-size-large.label   = Lar&ge
+
+cmd.font-size-other.format  = Other ($fontSize pt)…
+cmd.font-size-other.label   = &Other…
+cmd.font-size-other.help    = Prompts for a font size.
+
+cmd.goto-startup.label  = Open Auto-connect
+cmd.goto-startup.help   = Open all of your configured auto-connect URLs.
+
+cmd.goto-url.label  = Open Link
+cmd.goto-url.format = $label
+cmd.goto-url.params = <url> [<anchor>]
+cmd.goto-url.help   = Navigate to the url specified by <url>.  If the <url> is not an irc: url, it will be opened in the most recent browser window.  If <url> is an alias for a url, the optional <anchor> can be used to specify a named anchor within the url.
+
+cmd.goto-url-newwin.label  = Open Link in New Window
+cmd.goto-url-newwin.params = <url> [<anchor>]
+cmd.goto-url-newwin.help   = Navigate to the url specified by <url>.  If the <url> is not an irc: url, it will be opened in a new browser window.  If <url> is an alias for a url, the optional <anchor> can be used to specify a named anchor within the url.
+
+cmd.goto-url-newtab.label  = Open Link in New Tab
+cmd.goto-url-newtab.params = <url> [<anchor>]
+cmd.goto-url-newtab.help   = Navigate to the url specified by <url>.  If the <url> is not an irc: url, it will be opened in a new tab in the most recent browser window.  If <url> is an alias for a url, the optional <anchor> can be used to specify a named anchor within the url.
+
+cmd.goto-url-external.label  = Open Link in Default Browser
+cmd.goto-url-external.params = <url> [<anchor>]
+cmd.goto-url-external.help   = Navigate to the url specified by <url>.  If the <url> is not an irc: url, it will be opened in your system default browser.  If <url> is an alias for a url, the optional <anchor> can be used to specify a named anchor within the url.
+
+cmd.header.help = Toggles visibility of the header bar.
+
+cmd.help.params = [<pattern>]
+cmd.help.help   = Displays help on all commands matching <pattern>, if <pattern> is not given, displays help on all commands.
+
+cmd.hide-view.label  = &Hide Tab
+cmd.hide-view.params = [<view>]
+cmd.hide-view.help   = Drop the current view's icon from the tab strip, but save its contents.  The icon will reappear the next time there is activity on the view.
+
+cmd.homepage.label = Ambassador Homepage
+
+cmd.hop.label  = Give Half-operator Status
+cmd.hop.params = <nickname> [<...>]
+cmd.hop.help   = Gives half-operator status to <nickname> on current channel. Requires operator status.
+
+cmd.idle-away.help = Internal command used for automatically setting "away" status when idle.
+cmd.idle-back.help = Internal command used for automatically setting "back" status when returning from idle.
+
+cmd.reconnect.format = Reconnect To $networkName
+cmd.reconnect.label  = &Reconnect
+cmd.reconnect.params = [<reason>]
+cmd.reconnect.help   = Reconnects to the network represented by the active view when the command is executed providing the reason <reason> when disconnecting, or the default reason if <reason> is not specified.
+
+cmd.reconnect-all.label  = &Reconnect To All Networks
+cmd.reconnect-all.params = [<reason>]
+cmd.reconnect-all.help   = Reconnects to all networks providing the reason <reason> when disconnecting, or the default reason if <reason> is not specified.
+
+cmd.toggle-ui.params = <thing>
+cmd.toggle-ui.help   = Toggles the visibility of various pieces of the user interface.  <thing> must be one of: tabstrip, userlist, header, status.
+
+cmd.userlist.label  = User List
+cmd.userlist.key    = accel shift L
+
+cmd.tabstrip.label  = Tab Strip
+cmd.tabstrip.key    = accel shift T
+
+cmd.statusbar.label = Status Bar
+cmd.statusbar.key   = accel shift S
+
+cmd.header.label    = Header
+cmd.header.key      = accel shift H
+
+cmd.input-text-direction.params = <dir>
+cmd.input-text-direction.help   =
+
+cmd.text-direction.params = <dir>
+cmd.text-direction.help   =
+
+cmd.rtl.help  = Switches text direction to Right-to-Left.
+cmd.ltr.help  = Switches text direction to Left-to-Right.
+
+cmd.irtl.help = Switches input area direction to Right-to-Left.
+cmd.iltr.help = Switches input area direction to Left-to-Right.
+
+cmd.toggle-text-dir.label  = S&witch Text Direction
+cmd.toggle-text-dir.key    = accel shift X
+
+cmd.toggle-pref.params = <pref-name>
+cmd.toggle-pref.help   = Toggles the boolean preference specified by <pref-name>.
+
+cmd.toggle-usort.label = Sort Users By Mode
+cmd.toggle-ccm.label   = Collapse Co&nsecutive Messages
+cmd.toggle-copy.label  = Copy &Important Messages
+cmd.toggle-umode.label = Show Mode as Symbol
+cmd.toggle-timestamps.label = Show &Timestamps
+
+cmd.unban.label  = Un-ban
+cmd.unban.format = Un-ban from $channelName
+cmd.unban.params = <nickname>
+cmd.unban.help   = Removes the ban on a single user, or removes a specific ban mask from the channel's ban list.
+
+cmd.unexcept.params = <nickname>
+cmd.unexcept.help   = Removes a channel ban exception.
+
+cmd.user.params  = [<username> <description>]
+cmd.user.help    = Sets your username to <username> and your description (``Real Name'') to <description>. Equivalent to using the |name| and |desc| command. The new name and description will be used the next time you connect to the network. You can use this command without parameters to show the current username and description.
+
+cmd.userlist.help = Toggles the visibility of the user list.
+
+cmd.identify.params = [<password>]
+cmd.identify.help   = Identify with nickname services on the current server. If <password> is not provided, you will be asked to enter the password in a prompt with a masked textfield (so nobody will be able to read it when you type it).
+
+cmd.ignore.params = [<mask>]
+cmd.ignore.help   = Add someone to your ignore list for the current network. A nickname will suffice for <mask>, but you can also use a hostmask. With no parameters, it shows a list of all currently ignored users.
+
+cmd.install-plugin.params = [<url> [<name>]]
+cmd.install-plugin.help   = Installs a Ambassador plugin for you.
+cmd.install-plugin.label  = &Install Plugin…
+
+cmd.invite.params = <nickname> [<channel-name>]
+cmd.invite.help   = Invites <nickname> to <channel-name> or current channel if not supplied. Requires operator status if +i is set.
+
+cmd.j.params = <channel-name> [<key>]
+cmd.j.help   = This command is an alias for /join.
+
+cmd.join.label  = &Join Channel…
+cmd.join.key    = accel J
+cmd.join.params = [<channel-name> [<key>]]
+cmd.join.help   = Joins the global (name starts with #), local (name starts with &), or modeless (name starts with a +) channel named <channel-name>.  If no prefix is given, # is assumed.  Provides the key <key> if specified.
+
+cmd.join-charset.params = [<channel-name> <charset> [<key>]]
+cmd.join-charset.help   = Joins the global (name starts with #), local (name starts with &), or modeless (name starts with a +) channel named <channel-name>.  Messages will be encoded and decoded according to the character encoding specified by <charset>.  The <charset> parameter is independent of the default character encoding, which can be selected with the /charset command.  If no prefix is given, # is assumed.  Provides the key <key> if specified.
+
+cmd.jsconsole.label = JavaScript Console
+cmd.jsconsole.help  =
+cmd.jsconsole.key   = accel shift J
+
+cmd.jump-to-anchor.params = <anchor> [<channel-name>]
+cmd.jump-to-anchor.help   =
+
+cmd.kick.format = Kick from $channelName
+cmd.kick.label  = Kick
+cmd.kick.params = <nickname> [<reason>]
+cmd.kick.help   = Kicks <nickname> off the current channel. Requires operator status.
+
+cmd.kick-ban.format = Kickban from $channelName
+cmd.kick-ban.label  = Kickban
+cmd.kick-ban.params = <nickname> [<reason>]
+cmd.kick-ban.help   = Bans *!username@hostmask from the current channel, then kicks them off. Requires operator status.
+
+cmd.knock.params = <channel-name> [<reason>]
+cmd.knock.help   = Requests an invitation from the specified channel with optional reason. This command is not supported by all servers.
+
+cmd.label-user.format = «$nickname»
+cmd.label-user.label  = <unknown>
+cmd.label-user.params = <unspecified>
+cmd.label-user.help   =
+
+cmd.label-user-multi.format = «$userCount users»
+cmd.label-user-multi.label  = <unknown>
+cmd.label-user-multi.params = <unspecified>
+cmd.label-user-multi.help   =
+
+cmd.leave.format = Leave $channelName
+cmd.leave.label  = &Leave
+cmd.leave.params = [<channel-name>] [<reason>]
+cmd.leave.help   = Leaves the current channel. Use /delete to force the view to go away, losing its contents, or /hide to temporarily hide it, preserving its contents. Many servers do not support the optional <reason> parameter. Your preferences are used to determine whether to delete the tab. If you are dispatching this command from a script, you may override this behaviour with the <delete-when-done> parameter.
+
+cmd.links.help   = Displays the "links" to the current server. This is a list of the other servers in the network which are directly connected to the one you are connected to.
+
+cmd.list.params = [<channel-name>]
+cmd.list.help   = Lists channel name, user count, and topic information for the network/server you are attached to.  If you omit the optional channel argument, all channels will be listed.  On large networks, the server may disconnect you for asking for a complete list.
+
+cmd.list-plugins.params = [<plugin>]
+cmd.list-plugins.help   = If <plugin> is not provided, this command lists information on all loaded plugins.  If <plugin> is provided, only its information will be displayed.  If this command is dispatched from the console, you may specify <plugin> by either the plugin id, or index.
+
+cmd.load.params = <url>
+cmd.load.help   = Executes the contents of the url specified by <url>.  See also: The |initialScripts| pref.
+
+cmd.reload-plugin.params = <plugin>
+cmd.reload-plugin.help   = Reloads the plugin from the same url it was loaded from last time.  This will only work if the currently loaded version of the plugin can be disabled.
+
+cmd.log.params = [<state>]
+cmd.log.help   = Turns logging on or off for the current channel.  If <state> is provided and is |true|, |on|, |yes|, or |1|, logging will be turned on.  Values |false|, |off|, |no| and |0| will turn logging off.  Omit <state> to see the current logging state.  The state will be saved in prefs, so that if logging is on when you close Ambassador, it will resume logging the next time you join the channel.
+
+cmd.rlist.params = <regexp>
+cmd.rlist.help   = Lists channel name, user count, and topic information for the network/server you are attached to, filtered by the regular expression.
+
+cmd.reload-ui.help = Reload the Ambassador XUL file.  Used during development.
+
+cmd.map.help = Similar to /links, but provides a graphical "Network Map" of the IRC network. Mainly used for routing purposes.
+
+cmd.match-users.params = <mask>
+cmd.match-users.help   = Shows a list of all users whose hostmask matches <mask>.
+
+cmd.me.params = <action>
+cmd.me.help   = Sends the text <action> to the channel as a statement in the third person.  Try it and see!
+
+cmd.motd.help   = Displays the "Message of the Day", which usually contains information about the network and current server, as well as any usage policies.
+
+cmd.mode.params = [<target>] [<modestr> [<param> [<...>]]]
+cmd.mode.help   = Changes the channel or user mode of <target> using <modestr> and any subsequent <param> if added. When used from a channel view, <target> may be omitted. For a list of modes you may use, see http://irchelp.org.
+
+cmd.motif.params = [<motif>]
+cmd.motif.help   = Sets the default CSS file used for the message tabs.  <motif> can be a URL to a .css file, or the shortcut "dark" or "light".  See the ChatZilla motifs page at <http://chatzilla.hacksrus.com/motifs/> for more information on how to style Ambassador.  See also |network-motif|, |channel-motif|, |user-motif|.
+
+cmd.motif-dark.label = Dar&k Motif
+cmd.motif-light.label = &Light Motif
+
+cmd.msg.params = <nickname> <message>
+cmd.msg.help   = Sends the private message <message> to <nickname>.
+
+cmd.name.params = [<username>]
+cmd.name.help   = Changes the username displayed before your hostmask if the server you're connecting to allows it.  Some servers will only trust the username reply from the ident service.  You must specify this *before* connecting to the network. If you omit <username>, the current username will be shown.
+
+cmd.names.params = [<channel-name>]
+cmd.names.help   = Lists the users in a channel.
+
+cmd.network.params = <network-name>
+cmd.network.help   = Sets the current network to <network-name>
+
+cmd.networks.help   = Lists all available networks as clickable links.
+
+cmd.network-motif.params = [<motif> [<network>]]
+cmd.network-motif.help   = Sets the CSS file used for the message tab for the network <network>.  <motif> can be a URL to a .css file, or the shortcut "dark" or "light".  If <motif> is a minus ('-') character, the motif will revert to the global motif.  If <network> is not provided, the current network is assumed.  See the ChatZilla motifs page at <http://chatzilla.hacksrus.com/motifs/> for more information on how to style Ambassador.  See also |motif|.
+
+cmd.network-pref.params = [<pref-name> [<pref-value>]]
+cmd.network-pref.help    = Sets the value of the preference named <pref-name> to the value of <pref-value> on the current network.  If <pref-value> is not provided, the current value of <pref-name> will be displayed.  If both <pref-name> and <pref-value> are omitted, all preferences will be displayed.  If <pref-value> is a minus ('-') character, then the preference will revert back to its default value.
+
+cmd.nick.label  = Change nickname…
+cmd.nick.params = [<nickname>]
+cmd.nick.help   = Changes your nickname. If |nickname| is omited, a prompt is shown.
+
+cmd.notify.params = [<nickname> [<...>]]
+cmd.notify.help   = With no parameters, /notify shows you the online/offline status of all the users on your notify list.  If one or more <nickname> parameters are supplied, the nickname(s) will be added to your notify list if they are not yet on it, or removed from it if they are.
+
+cmd.notice.params = <nickname> <message>
+cmd.notice.help   = Sends the notice <message> to <nickname>.
+
+cmd.op.label  = Give Operator Status
+cmd.op.params = <nickname> [<...>]
+cmd.op.help   = Gives operator status to <nickname> on current channel. Requires operator status.
+
+cmd.open-at-startup.params = [<toggle>]
+cmd.open-at-startup.help   = Used to add the current view to the list of views that will be automatically opened at startup.  If <toggle> is not provided, the status of the current view will be displayed.  <toggle> can be one of: yes, on, true, 1, no, off, false, 0, or toggle, to toggle the current state.
+
+cmd.oper.params = <opername> [<password>]
+cmd.oper.help   = Requests IRC Operator status from the current server. If <password> is not provided, you will be asked to enter the password in a prompt with a masked textfield (so nobody will be able to read it when you type it).
+
+cmd.print.label  = &Print…
+cmd.print.key    = accel P
+cmd.print.params =
+cmd.print.help   = Opens the print dialog for the current view.
+
+cmd.save.label = Save View &As…
+cmd.save.key = accel S
+cmd.save.params = [<filename> [<savetype>]]
+cmd.save.help = Save the current view as file <filename>. If <filename> is omitted, a Save As… dialog will be shown. <savetype> can be either |complete|, |htmlonly| or |text|. If it is omitted, it is deduced from the file extension. Files with the extension .html, .xhtml, .xhtm or .htm will be saved as complete views, .txt files as text files. Any other extensions will throw an error if <savetype> is not provided.
+
+cmd.say.params = <message>
+cmd.say.help   = Sends a message to the current view. This command is used automatically by Ambassador when you type text that does not begin with the "/" character.
+
+cmd.stats.params = [<params>]
+cmd.stats.help = Request server statistics. Use this command with no parameters to get a server-specific list of available parameters for use with this command.
+
+cmd.time.params = [<nickname>]
+cmd.time.help   = Asks <nickname> what time it is on their machine.  Their IRC client may or may not show them that you've asked for this information.  Ambassador currently does not.  If you do not specify <nickname>, Ambassador will ask the server for the time it is on the server.
+cmd.time.label  = Get Local Time
+
+cmd.timestamps.params = [<toggle>]
+cmd.timestamps.help   = Sets the visibility of timestamps in the current view. If <toggle> is provided and is |true|, |on|, |yes|, or |1|, timestamps will be turned on.  Values |false|, |off|, |no| and |0| will turn timestamps off, and |toggle| will toggle the state.  Omit <toggle> to see the current state.
+
+cmd.toggle-oas.format = Open This $viewType at Startup
+cmd.toggle-oas.label  = Open at &Startup
+
+cmd.pass.params = <password>
+cmd.pass.help   = Sends a password to the server for use when connecting to password-protected servers.
+
+cmd.passmgr.label = Password Manager
+cmd.passmgr.help  =
+
+cmd.ping.params = <nickname>
+cmd.ping.help   = Ping takes its name from the technique of measuring distance with sonar.  In IRC, it is used to measure the time it takes to send a message to someone, and receive a response.  Specify a channel to ping everyone in that channel.  Some IRC clients will display ping requests to the user.  Ambassador does not.
+cmd.ping.label  = Ping User
+
+cmd.plugin-pref.params = <plugin> [<pref-name> [<pref-value>]]
+cmd.plugin-pref.help = Sets the value of the plugin's preference named <pref-name> to the value of <pref-value>.  If <pref-value> is not provided, the current value of <pref-name> will be displayed.  If both <pref-name> and <pref-value> are omitted, all preferences for <plugin> will be displayed.  If <pref-value> is a minus ('-') character, then the preference will revert back to its default value.
+
+cmd.pref.params  = [<pref-name> [<pref-value>]]
+cmd.pref.help    = Sets the value of the preference named <pref-name> to the value of <pref-value>.  If <pref-value> is not provided, the current value of <pref-name> will be displayed.  If both <pref-name> and <pref-value> are omitted, all preferences will be displayed.  If <pref-value> is a minus ('-') character, then the preference will revert back to its default value.
+
+cmd.query.label  = Open Private Chat
+cmd.query.params = <nickname> [<message>]
+cmd.query.help   = Opens a one-on-one chat with <nickname>.  If <message> is supplied, it is sent as the initial private message to <nickname>.
+
+cmd.quit.label  = &Quit Ambassador
+cmd.quit.params = [<reason>]
+cmd.quit.help   = Quit Ambassador.
+
+cmd.quit-mozilla.label  = &Quit
+cmd.quit-mozilla.help   = Quit &brandShortName;.
+
+cmd.quote.params = <irc-command>
+cmd.quote.help   = Sends a raw command to the IRC server, not a good idea if you don't know what you're doing. see IRC RFC1459 <http://www.irchelp.org/irchelp/rfc1459.html> for complete details.
+
+cmd.rejoin.params = [<reason>]
+cmd.rejoin.help   = Rejoins the channel displayed in the current view. Only works from a channel view.
+cmd.rejoin.format = Rejoin $channelName
+cmd.rejoin.label  = Rejoin
+
+cmd.rename.params = [<label>]
+cmd.rename.help   = Change the label of the current tab to <label>.
+cmd.rename.label  = Rename Tab…
+
+cmd.server.params = <hostname> [<port> [<password>]]
+cmd.server.help   = Connects to server <hostname> on <port>, or 6667 if <port> is not specified.  Provides the password <password> if specified. If you are already connected, the view for <hostname> is made current.  If that view has been deleted, it is recreated.
+
+cmd.set-current-view.params = <view>
+cmd.set-current-view.help   =
+
+cmd.sslserver.params = <hostname> [<port> [<password>]]
+cmd.sslserver.help   = Connects to server using SSL <hostname> on <port>, or 6697 if <port> is not specified.  Provides the password <password> if specified. If you are already connected, the view for <hostname> is made current.  If that view has been deleted, it is recreated.
+
+cmd.ssl-exception.params = [<hostname> <port> [<connect>]]
+cmd.ssl-exception.help = Opens the dialog to add an SSL certificate exception for <hostname>. If <connect> is true then a connection to <hostname> will be initiated after the exception is added.
+
+cmd.squery.params = <service> [<commands>]
+cmd.squery.help   = Sends the commands <commands> to the service <service>.
+
+cmd.stalk.params = [<text>]
+cmd.stalk.help   = Add <text> to list of words for which you would like to see alerts. Whenever a person with a nickname matching <text> speaks, or someone says a phrase containing <text>, your Ambassador window will become active (on some operating systems) and its taskbar icon will flash (on some operating systems.) If <text> is omitted the list of stalk words is displayed.
+
+cmd.status.help = Shows status information for the current view.
+
+cmd.statusbar.help = Toggles the visibility of the status bar.
+
+cmd.supports.help = Lists the capabilities of the current server, as reported by the 005 numeric.
+
+cmd.testdisplay.help = Displays a sample text.  Used to preview styles.
+
+cmd.topic.params = [<new-topic>]
+cmd.topic.help   = If <new-topic> is specified and you are a chanop, or the channel is not in 'private topic' mode (+t), the topic will be changed to <new-topic>.  If <new-topic> is *not* specified, the current topic will be displayed.
+
+cmd.tabstrip.help = Toggles the visibility of the channel tab strip.
+
+cmd.unalias.params = <alias-name>
+cmd.unalias.help   = Removes the named alias.
+
+cmd.unignore.params = <mask>
+cmd.unignore.help   = Removes someone from your ignore list for the current network. A nickname will suffice for <mask>, but you can also use a hostmask.
+
+cmd.unstalk.params = <text>
+cmd.unstalk.help   = Remove word from list of terms for which you would like to see alerts.
+
+cmd.update.label = Update...
+cmd.update.help  =
+
+cmd.urls.params = [<number>]
+cmd.urls.help   = Displays the last few URLs seen by Ambassador. Specify <number> to change how many it displays, or omit to display the default 10.
+
+cmd.userhost.params = <nickname> [<...>]
+cmd.userhost.help   = Requests the hostmask of every <nickname> given.
+
+cmd.userip.params = <nickname> [<...>]
+cmd.userip.help   = Requests the IP-address of every <nickname> given.
+
+cmd.disable-plugin.params = <plugin>
+cmd.disable-plugin.help   = This command calls the plugin's disablePlugin function, if it exists.  There are no guarantees that the plugin will properly disable itself.
+
+cmd.usermode.params = [<new-mode>]
+cmd.usermode.help   = Changes or displays the current user mode.
+
+cmd.user-motif.params = [<motif> [<user>]]
+cmd.user-motif.help   = Sets the CSS file used for the message tab for the user <user>.  <motif> can be a URL to a .css file, or the shortcut "dark" or "light".  If <motif> is a minus ('-') character, the motif will revert to the network motif.  If <user> is not provided, the current user is assumed.  See the ChatZilla motifs page at <http://chatzilla.hacksrus.com/motifs/> for more information on how to style Ambassador.  See also |motif|.
+
+cmd.user-pref.params = [<pref-name> [<pref-value>]]
+cmd.user-pref.help    = Sets the value of the preference named <pref-name> to the value of <pref-value> on the current user.  If <pref-value> is not provided, the current value of <pref-name> will be displayed.  If both <pref-name> and <pref-value> are omitted, all preferences will be displayed.  If <pref-value> is a minus ('-') character, then the preference will revert back to its default value.
+
+cmd.websearch.help   = Runs a web search for the currently-selected text.
+cmd.websearch.params = <selected-text>
+cmd.websearch.format = Search the web for "$selectedText""
+cmd.websearch.label  = Search the web
+
+cmd.version.label  = Get Version Information
+cmd.version.params = [<nickname>]
+cmd.version.help   = Asks <nickname> what irc client they're running.  Their IRC client may or may not show them that you've asked for this information.  Ambassador currently does not.  If you do not specify <nickname>, Ambassador will ask the server for the version of the IRCserver software it is running.
+
+cmd.voice.label  = Give Voice Status
+cmd.voice.params = <nickname> [<...>]
+cmd.voice.help   = Gives voice status to <nickname> on current channel. Requires operator (or half-operator) status.
+
+cmd.who.params = <rest>
+cmd.who.help   = List users who have name, host, or description information matching <rest>.
+
+cmd.whois.label  = Who is
+cmd.whois.params = <nickname> [<...>]
+cmd.whois.help   = Displays information about the user <nickname>, including 'real name', server connected to, idle time, and signon time.  Note that some servers will lie about the idle time.  The correct idle time can usually be obtained by using |wii| instead of |whois|.
+
+cmd.wii.params = <nickname> [<...>]
+cmd.wii.help   = Displays the same information as |whois|, but asks the server to include the user's real idle time.
+
+cmd.whowas.label  = Who was
+cmd.whowas.params = <nickname> [<limit>]
+cmd.whowas.help   = Displays the last known information about the user <nickname>, including 'real name', for a user that has left the server.
+
+## dispatch-related error messages ##
+msg.err.internal.dispatch = Internal error dispatching command ``%1$S''.
+msg.err.internal.hook   = Internal error processing hook ``%1$S''.
+msg.err.invalid.param   = Invalid value for parameter %1$S (%2$S).
+msg.err.disabled        = Sorry, ``%1$S'' is currently disabled.
+msg.err.notimplemented  = Sorry, ``%1$S'' has not been implemented.
+msg.err.required.param  = Missing required parameter %1$S.
+msg.err.ambigcommand    = Ambiguous command, ``%1$S'', %2$S commands match [%3$S].
+msg.err.required.nr.param = Missing %1$S parameters. This alias requires at least %2$S parameters.
+msg.err.max.dispatch.depth = Reached max dispatch depth while attempting to dispatch ``%1$S''.
+
+## Ambassador error messages ##
+msg.err.invalid.regex   = Invalid Regular Expression. For help with regular expressions, see http://en.wikipedia.org/wiki/Regular_expression#Syntax.
+msg.err.invalid.pref    = Invalid value for preference %1$S (%2$S).
+msg.err.invalid.file    = Invalid file <%1$S> renamed to <%2$S>.
+msg.err.failure         = Operation Failed: %1$S.
+msg.err.scriptload      = Error loading subscript from <%1$S>.
+msg.err.pluginapi.noid      = Plugin <%1$S> does not have an id.
+msg.err.pluginapi.faultyid  = Plugin <%1$S> does not have a valid id. Plugin ids may only contain alphanumeric characters, underscores (_) and dashes (-).
+msg.err.pluginapi.noenable  = Plugin <%1$S> does not have an enable() method.
+msg.err.pluginapi.nodisable = Plugin <%1$S> does not have a disable() method.
+msg.err.invalid.scheme  = Invalid scheme in url <%1$S>.
+msg.err.item.not.found  = Startup script item <%1$S> does not exist or is inaccessible.
+msg.err.unknown.pref    = The preference ``%1$S'' is not known to Ambassador.
+msg.err.unknown.network = The network ``%S'' is not known to Ambassador.
+msg.err.unknown.channel = The channel ``%S'' is not known to Ambassador.
+msg.err.unknown.user    = The user ``%S'' is not known to Ambassador.
+msg.err.unknown.command = The command ``%S'' is not known to Ambassador.
+msg.err.unknown.stalk   = Not stalking %S.
+msg.err.unknown.motif   = The motif ``%S'' is not known to Ambassador.
+msg.err.invalid.charset = Invalid character encoding mode ``%S''.
+msg.err.improper.view   = ``%S'' cannot be used from this view.
+msg.err.not.connected   = Not connected.
+msg.err.last.view       = Cannot delete last view.
+msg.err.last.view.hide  = Cannot hide last view.
+msg.err.bad.ircurl      = Invalid IRC URL ``%S''.
+msg.err.need.network  = Command ``%1$S'' must be run in the context of a network.
+msg.err.need.server   = Command ``%1$S'' must be run in the context of an attached server.
+msg.err.need.channel  = Command ``%1$S'' must be run in the context of a channel.
+msg.err.need.user     = Command ``%1$S'' must be run in the context of a user.
+msg.err.need.recip    = Command ``%1$S'' must be run in the context of a user or a channel.
+msg.err.no.default    = Please do not just type into this tab, use an actual command instead.
+msg.err.no.match      = No match for ``%S''.
+msg.err.no.socket     = Error creating socket.
+msg.err.no.secure     = The network ``%S'' has no secure servers defined.
+msg.err.cancelled     = Connection process canceled.
+msg.err.offline       = &brandShortName; is in ``offline mode''. No network connections can be made in this mode.
+msg.err.badalias      = Malformed alias: %S"
+msg.err.no.ctcp.cmd   = %S is not a valid CTCP function for this client
+msg.err.no.ctcp.help  = %S does not have any help information
+msg.err.unknown.host  = The host application UID "%S" is not recognised. Please report what application you are running Ambassador in, and the UID given.
+msg.err.unable.to.print = The current view does not support printing.
+msg.err.unsupported.command = The server does not support the ``%S'' command.
+msg.err.invalid.mode  = The mode string you entered (``%S'') is invalid. A valid mode string consists of one or more sequences of a + or - followed by one or more alphabetical characters.
+msg.err.away.save     = Saving the list of away messages failed (%S).
+msg.err.inputhistory.not.writable = Unable to save input history to ``%S''.
+msg.err.urls.not.writable = Unable to save URL log to ``%S''.
+msg.err.invalid.url   = ``%S'' is not a valid url nor an alias for a url, and therefore could not be loaded.
+msg.err.no.channel    = When running the ``%S'' command, you should either provide a channel name, or run the command in the context of a channel.
+msg.err.no.idleservice = Ambassador can't determine when you're away in your version of &brandShortName;. The auto-away feature will now be disabled.
+msg.err.flushssl.usehost = Please use your browser's history manager to clear active login data.
+msg.err.update.usehost = Please use your browser's add-on update manager to update Ambassador.
+msg.err.update.disabled = In-app updates are not available. Please manually download the latest version from the Ambassador releases page: <https://github.com/Ascrod/ambassador/releases/latest/>
+
+msg.warn.pac.loading = The automatic proxy configuration file has not loaded yet; Ambassador will retry shortly.
+
+# Specific bug messages.
+msg.bug318419.warning = Ambassador has detected a potential abnormality in its internal data. You will not be able to send any form of communication at this time, although it might appear you can. The most likely cause is Mozilla Bug 318419 <https://bugzilla.mozilla.org/show_bug.cgi?id=318419>. You are strongly advised to restart the host application (&brandShortName;) to prevent further problems.
+msg.bug318419.error   = Ambassador has detected a serious abnormality in its internal data. You will not be able to send any form of communication at this time, although it might appear you can. The most likely cause is Mozilla Bug 318419 <https://bugzilla.mozilla.org/show_bug.cgi?id=318419>. You MUST restart the host application (&brandShortName;) to fix this.
+
+# Ask for nick pass if not explicitly given in the command:
+msg.need.identify.password = Please enter the Nickname Services password for this nickname.
+
+# Ask for oper pass if not explicitly given in the command:
+msg.need.oper.password = Please enter a password for obtaining IRC Operator privileges.
+
+# Better IRC error messages
+msg.irc.381 = You are now an IRC Operator.
+msg.irc.401 = The nickname ``%S'' does not exist.
+msg.irc.402 = The server ``%S'' does not exist.
+msg.irc.403 = The channel ``%S'' does not exist.
+msg.irc.421 = The command ``%S'' is not known to the server.
+msg.irc.464 = Incorrect password, please try again with the correct password.
+msg.irc.464.login = Please specify your password using the "/pass" command to continue connecting.
+msg.irc.471 = This channel has reached its set capacity; you cannot join it.
+msg.irc.473 = This channel is invite-only. You must have an invite from an existing member of the channel to join.
+msg.irc.474 = You are banned from this channel.
+msg.irc.475 = This channel needs a key. You must provide the correct key to join the channel. See "/help join" for details on joining a channel with a key.
+msg.irc.476 = You provided a channel mask which the server considers to be invalid.
+msg.irc.477 = This channel requires that you have registered and identified yourself with the network's nickname registration services (e.g. NickServ). Please see the documentation of this network's nickname registration services that should be found in the MOTD (/motd to display it).
+msg.irc.491 = Only few of mere mortals may try to enter the twilight zone (your host did not match any configured 'O-lines').
+
+# This is an extended version that is only used if the server support /knock.
+msg.irc.471.knock = %S You might be able to use "/knock %S" to ask the channel operators to invite you in. [[Knock][Asks the channel operators to let you in][%S]]
+msg.irc.473.knock = %S Use "/knock %S" to ask the channel operators to invite you in. [[Knock][Asks the channel operators to let you in][%S]]
+msg.irc.475.knock = %S You might be able to use "/knock %S" to ask the channel operators to invite you in. [[Knock][Asks the channel operators to let you in][%S]]
+
+msg.val.on  = on
+msg.val.off = off
+
+msg.plugin.enabled = Plugin ``%S'' is now enabled.
+msg.plugin.disabled = Plugin ``%S'' is now disabled.
+
+msg.leave.inputbox = There is nothing to tab-complete. Use F6 to cycle through the user list, input box and the chat output.
+
+## formatting ##
+msg.fmt.usage = "%1$S %2$S"
+msg.fmt.jsexception = "%1$S: %2$S @ <%3$S> %4$S"
+# 1: error number,  2: error text, 3: file name, 4: line number, 5: function name
+# 1: pref name 2: value
+msg.fmt.pref = Preference ``%1$S'' is ``%2$S''.
+msg.fmt.netpref = Network preference ``%1$S'' is ``%2$S''.
+msg.fmt.chanpref = Channel preference ``%1$S'' is ``%2$S''.
+msg.fmt.userpref = User preference ``%1$S'' is ``%2$S''.
+msg.fmt.pluginpref = Plugin preference ``%1$S'' is ``%2$S''.
+
+msg.fmt.plugin1 = Plugin at index %S, loaded from <%S>.
+msg.fmt.plugin2 = id: %S, version: %S, enabled: %S, status: %S.
+msg.fmt.plugin3 = Description: %S.
+
+msg.fmt.usercount = "%S, %S@, %S%%, %S+"
+msg.fmt.alias     = "%S = %S"
+msg.fmt.seconds   = "%S seconds
+
+msg.fmt.matchlist = "%S matches for ``%S'': [%S]
+msg.fmt.ctcpreply = CTCP %S reply ``%S'' from %S"
+msg.fmt.chanlist  = "%S   %S   %S"
+msg.fmt.logged.on = "%S is logged in as %S"
+
+# 1: local short date/time, 2: nick info
+msg.fmt.status    = "%S %S"
+
+msg.unknown   = <unknown>
+msg.none      = <none>
+msg.na        = <n/a>
+
+msg.commasp   = ", "
+msg.always    = always
+msg.and       = and
+msg.primary   = primary
+msg.secondary = secondary
+msg.you       = you
+msg.network   = Network
+msg.server    = Server
+msg.channel   = Channel
+msg.user      = User
+msg.client    = Client
+msg.view      = View
+msg.tab       = Tab
+msg.loading   = Loading
+msg.error     = Error
+msg.here      = here
+msg.gone      = gone
+msg.connecting   = Connecting
+msg.connected    = Connected
+msg.disconnected = Disconnected
+
+msg.days    = "%S days
+msg.hours   = "%S hours
+msg.minutes = "%S minutes
+msg.seconds = "%S seconds
+msg.day     = 1 day
+msg.hour    = 1 hour
+msg.minute  = 1 minute
+msg.second  = 1 second
+
+
+msg.rsp.hello = [HELLO]
+msg.rsp.help  = [HELP]
+msg.rsp.usage = [USAGE]
+msg.rsp.error = [ERROR]
+msg.rsp.warn  = [WARNING]
+msg.rsp.info  = [INFO]
+msg.rsp.evin  = [EVAL-IN]
+msg.rsp.evout = [EVAL-OUT]
+msg.rsp.disconnect = [QUIT]
+
+# For these menu labels, too, an accesskey may be specified using a .accesskey
+# string, or by prefixing the desired letter with "&" in the label.
+# The accesskey string should have the form: msg.mnu.<menuname>.accesskey
+msg.mnu.ambassador = &Ambassador
+msg.mnu.irc        = &IRC
+msg.mnu.edit       = &Edit
+msg.mnu.help       = &Help
+msg.mnu.view       = &View
+msg.mnu.tools      = &Tools
+msg.mnu.views      = &Views
+msg.mnu.motifs     = Co&lor Scheme
+msg.mnu.opcommands = &Operator Commands
+msg.mnu.usercommands = &User Commands
+msg.mnu.fonts      = &Font Family and Size
+
+msg.client.name       = *client*
+msg.cant.disable      = Unable to disable plugin %S.
+msg.cant.enable       = Unable to enable plugin %S.
+msg.is.disabled       = Plugin %S is already disabled.
+msg.is.enabled        = Plugin %S is already enabled.
+msg.no.help           = Help not available.
+msg.no.cmdmatch       = No commands match ``%1$S''.
+msg.no.plugins        = There are no plugins loaded.
+msg.cmdmatch          = Commands matching ``%1$S'' are [%2$S].
+msg.default.alias.help = This command is an alias for |%1$S|.
+msg.extra.params      = Extra parameters ``%1$S'' ignored.
+msg.version.reply     = Ambassador %S [%S]
+msg.source.reply      = https://github.com/ascrod/ambassador/
+msg.nothing.to.cancel = No connection or /list in progress, nothing to cancel.
+msg.cancelling        = Cancelling connection to ``%S''…
+msg.cancelling.list   = Cancelling /list request…
+msg.current.charset      = Using ``%S'' as default character encoding.
+msg.current.charset.view = Using ``%S'' as character encoding for this view.
+msg.current.css       = Using <%S> as default motif.
+msg.current.css.net   = Using <%S> as default motif for this network.
+msg.current.css.chan  = Using <%S> as motif for this channel.
+msg.current.css.user  = Using <%S> as motif for this user.
+msg.no.dynamic.style  = Sorry, but your version of &brandShortName; doesn't support styling the entire application with a motif. This functionality will now be disabled.
+msg.subscript.loaded  = Subscript <%1$S> loaded with result ``%2$S''.
+msg.user.info         = Default nickname, ``%S'', username ``%S'', and description ``%S''.
+msg.connection.info   = "%S: User %S connected via %S:%S (%S server).
+msg.server.info       = "%S: Connected for %S, last ping: %S, server roundtrip (lag): %S seconds.
+msg.connect.via       = Connected via %S"
+msg.user.mode         = User mode for %S is now %S"
+msg.not.connected     = "%S: Not connected.
+msg.insecure.server   = Your connection to the server ``%S'' is not secure.
+msg.secure.connection = Signed by %S"
+msg.security.info     = Displays security information about the current connection
+msg.going.offline     = &brandShortName; is trying to go into offline mode. This will disconnect you from ALL the networks and channels you're connected to.
+msg.really.go.offline = Go Offline
+msg.dont.go.offline   = Don't Go Offline
+msg.offlinestate.offline = You are offline. Click the icon to go online.
+msg.offlinestate.online  = You are online. Click the icon to go offline.
+msg.member            = Member
+msg.operator          = Operator member
+msg.voiced            = Voiced member
+msg.voiceop           = Operator and voiced member
+msg.no.mode           = no mode
+msg.topic.info        = "%S, %S: Topic, ``%S''
+msg.notopic.info      = "%S, %S: No topic.
+msg.channel.info      = "%S: %S of %S (%S) <%S>
+msg.channel.details   = "%S/%S: %S users total, %S operators, %S voiced.
+msg.nonmember         = "%S: No longer a member of %S.
+msg.end.status        = End of status.
+msg.networks.heada    = Available networks are [
+msg.networks.headb    = ]. [[Edit][Edit the list of available networks.][%S]]
+msg.messages.cleared  = Messages Cleared.
+msg.match.unchecked   = (%S users were not checked)
+msg.matching.nicks    = The following users matched your query: %S. %S
+msg.no.matching.nicks = There were no users matching your query. %S
+msg.commands.header   = Type /help <command-name> for information about a specific command.
+msg.matching.commands = Currently implemented commands matching the pattern ``%S'' are [%S].\nType /help <command-name> for information about a specific command.
+msg.all.commands      = Currently implemented commands are [%S].
+msg.help.intro        = Help is available from many places:\n  - |/commands| lists all the built-in commands in Ambassador. Use |/help <command-name>| to get help on individual commands.\n  - The IRC Help website <http://www.irchelp.org/> provides introductory material for new IRC users. \n  - The ChatZilla FAQ <http://chatzilla.hacksrus.com/faq> answers many common questions about using Ambassador.
+msg.about.version     = "%S [[Details][Opens the about dialog for more details][%S]]
+msg.about.homepage    = Please visit the Ambassador homepage at <https://github.com/Ascrod/ambassador/> for more information.
+msg.newnick.you       = YOU are now known as %S
+msg.newnick.notyou    = "%S is now known as %S
+msg.view.hidden       = "%S (hidden)
+
+msg.localeurl.homepage  = https://github.com/Ascrod/ambassador/
+msg.localeurl.faq       = http://chatzilla.hacksrus.com/faq/
+
+msg.no.notify.list    = Your notify list is empty.
+msg.notify.addone     = "%S has been added to your notify list.
+msg.notify.addsome    = "%S have been added to your notify list.
+msg.notify.delone     = "%S has been removed from your notify list.
+msg.notify.delsome    = "%S have been removed from your notify list.
+
+msg.not.an.alias  = No such alias: %S.
+msg.alias.removed = Removed alias: %S.
+msg.alias.created = Created alias: %S = %S.
+msg.no.aliases    = No aliases are defined.
+
+msg.no.stalk.list     = No stalking victims.
+msg.stalk.list        = Currently stalking [%S].
+msg.stalk.add         = Now stalking %S.
+msg.stalk.del         = No longer stalking %S.
+msg.stalking.already  = Already stalking %S.
+
+msg.status         = Status
+msg.title.net.on   = User %S on ``%S'' (%S:%S)
+msg.title.net.off  = User %S, not connected to network ``%S''
+msg.title.nonick   = <unregistered-user>
+msg.title.no.topic = No Topic
+msg.title.no.mode  = No Mode
+msg.title.channel  = "%S on %S (%S): %S"
+msg.title.user     = Conversation with %S %S"
+msg.title.dccchat  = DCC Conversation with %S"
+msg.title.dccfile.send = "%S%% of ``%S'' sent to %S"
+msg.title.dccfile.get  = "%S%% of ``%S'' received from %S"
+msg.title.unknown  = Ambassador
+msg.title.activity = "%S -- Activity [%S]
+
+msg.output.url       = URL
+msg.output.knownnets = Known Networks
+msg.output.connnets  = Connected Networks
+msg.output.notconn   = Not Connected
+msg.output.lag       = Lag
+msg.output.mode      = Mode
+msg.output.users     = Users
+msg.output.topic     = Topic
+msg.output.via       = Connected via
+msg.output.to        = Connected to
+msg.output.file      = File
+msg.output.progress  = Progress
+msg.output.cancel    = Cancel
+
+msg.logging.off     = Logging is off.
+msg.logging.on      = Logging is on.  Log output is going to file <%S>.
+msg.logfile.closed  = Logfile closed.
+msg.logfile.error   = Unable to open file <%S>. Logging disabled.
+msg.logfile.opened  = Now logging to <%S>.
+msg.logfile.closing = Closing log file <%S>.
+msg.logfile.write.error = Unable to write to file <%S>. Logging disabled.
+msg.logging.icon.off = Logging is off. Click the icon to start logging this view.
+msg.logging.icon.on  = Logging is on. Click the icon to stop logging this view.
+
+msg.alert.icon.off = Message notifications are off. Click the icon to start showing notifications for new messages.
+msg.alert.icon.on  = Message notifications are on. Click the icon to stop showing notifications for new messages.
+
+msg.already.connected  = You are already connected to ``%S''.
+msg.enter.nick         = Please select a nickname
+msg.network.connecting = Attempting to connect to ``%S''.  Use /cancel to abort.
+
+msg.jumpto.button         = [[%1$S][Jump to this message in %1$S][%2$S]]
+msg.jumpto.err.nochan     = ``%S'' is no longer open.
+msg.jumpto.err.noanchor   = The anchor cannot be found.
+
+msg.banlist.item      = "%S banned %S from %S on %S.
+msg.banlist.button    = [[Remove][Remove this ban][%S]]
+msg.banlist.end       = End of %S ban list.
+msg.exceptlist.item   = "%S excepted %S from bans in %S on %S.
+msg.exceptlist.button = [[Remove][Remove this ban exception][%S]]
+msg.exceptlist.end    = End of %S exception list.
+
+msg.channel.needops   = You need to be an operator in %S to do that.
+
+msg.ctcphelp.clientinfo = CLIENTINFO gives information on available CTCP commands
+msg.ctcphelp.action     = ACTION performs an action at the user
+msg.ctcphelp.time       = TIME gives the local date and time for the client
+msg.ctcphelp.version    = VERSION returns the client's version
+msg.ctcphelp.source     = SOURCE returns an address where you can obtain the client
+msg.ctcphelp.os         = OS returns the client's host's operating system and version
+msg.ctcphelp.host       = HOST returns the client's host application name and version
+msg.ctcphelp.ping       = PING echos the parameter passed to the client
+msg.ctcphelp.dcc        = DCC requests a direct client connection
+
+# DCC CHAT messages.
+msg.dccchat.sent.request = Sent DCC Chat offer to ``%S'' from YOU (%S:%S) %S.
+msg.dccchat.got.request  = Got DCC Chat offer from ``%S'' (%S:%S) %S.
+msg.dccchat.accepting        = Auto-accepting DCC Chat offer from ``%S'' (%S:%S) in %S seconds %S.
+msg.dccchat.accepting.now    = Auto-accepting DCC Chat offer from ``%S'' (%S:%S).
+msg.dccchat.accepted     = Accepted DCC Chat with ``%S'' (%S:%S).
+msg.dccchat.declined     = Declined DCC Chat with ``%S'' (%S:%S).
+msg.dccchat.aborted      = Aborted DCC Chat with ``%S'' (%S:%S).
+msg.dccchat.failed       = Failed DCC Chat with ``%S'' (%S:%S).
+msg.dccchat.opened       = DCC Chat with ``%S'' (%S:%S) connected.
+msg.dccchat.closed       = DCC Chat with ``%S'' (%S:%S) disconnected.
+
+# DCC FILE messages.
+msg.dccfile.sent.request = Sent DCC File Transfer offer to ``%S'' from YOU (%S:%S) of ``%S'' (%S) %S.
+msg.dccfile.got.request  = Got DCC File Transfer offer from ``%S'' (%S:%S) of ``%S'' (%S) %S.
+msg.dccfile.accepting        = Auto-accepting DCC File Transfer offer from ``%S'' (%S:%S) of ``%S'' (%S) in %S seconds %S.
+msg.dccfile.accepting.now    = Auto-accepting DCC File Transfer offer from ``%S'' (%S:%S) of ``%S'' (%S).
+# 1 = file, 2 = to/from, 3 = nick, 4 = IP, 5 = port.
+msg.dccfile.accepted     = Accepted DCC File Transfer of ``%S'' %S ``%S'' (%S:%S).
+msg.dccfile.declined     = Declined DCC File Transfer of ``%S'' %S ``%S'' (%S:%S).
+msg.dccfile.aborted      = Aborted DCC File Transfer of ``%S'' %S ``%S'' (%S:%S).
+msg.dccfile.failed       = Failed DCC File Transfer of ``%S'' %S ``%S'' (%S:%S).
+msg.dccfile.opened       = DCC File Transfer of ``%S'' %S ``%S'' (%S:%S) started.
+msg.dccfile.closed.sent  = DCC File Transfer of ``%S'' %S ``%S'' (%S:%S) finished.
+# 6 = path, 7 = command for opening the folder
+msg.dccfile.closed.saved     = DCC File Transfer of ``%S'' %S ``%S'' (%S:%S) finished. File saved to ``%S''. [[Open Containing Folder][Open the folder containing the downloaded file][%S]]
+msg.dccfile.closed.saved.mac = DCC File Transfer of ``%S'' %S ``%S'' (%S:%S) finished. File saved to ``%S''. [[Show In Finder][Show the folder containing the file in Finder][%S]]
+
+# 1 = percent, 2 = current pos, 3 = total size, 4 = speed.
+msg.dccfile.progress     = %S%% complete, %S of %S, %S.
+msg.dccfile.send         = Pick file to send
+msg.dccfile.save.to      = Save incoming file (%S)
+msg.dccfile.err.notfound = The file specified could not be found.
+msg.dccfile.err.notafile = The path specified is not a normal file.
+msg.dccfile.err.notreadable = The file specified cannot be read.
+
+# General DCC messages.
+msg.dcc.pending.matches  = "%S pending incoming DCC offers matched.
+msg.dcc.accepted.matches = "%S DCC connections matched.
+msg.dcc.matches.help     = You must specify enough of the user's nickname to uniquely identify the request, or include the request type and even the filename if necessary.
+
+msg.dcc.not.enabled      = DCC is disabled. If you need DCC functionality, you may turn it on from the Preferences window.
+msg.dcc.not.possible     = DCC is unavailable in this version of &brandShortName; - the feature "scriptable server sockets" is missing. Mozilla builds after 2003-11-15 should contain this feature (e.g. Mozilla 1.6 or later).
+msg.dcc.err.nouser       = Must specify |nickname| or run the command from a query view.
+msg.dcc.err.accept.time  = You cannot use the short form of |/dcc-accept| within the first 10 seconds of receiving a DCC request.
+msg.dcc.err.notdcc       = Must specify |nickname| or run the command from a DCC view.
+
+# /dcc-list words and phrases.
+msg.dcclist.dir.in       = incoming
+msg.dcclist.dir.out      = outgoing (offer)
+msg.dcclist.to           = to
+msg.dcclist.from         = from
+## Params: index, state, direction (incoming/outgoing), DCC type, direction (to/from), user (ip:port), commands.
+msg.dcclist.line         = %S: %S %S DCC %S %S %S (%S:%S) %S
+## Params: waiting, running, done.
+msg.dcclist.summary      = DCC sessions: %S pending, %S connected, %S failed.
+
+msg.dccaccept.disabled  = Currently not auto-accepting DCC on this network.
+msg.dccaccept.list      = Currently auto-accepting DCC on this network from [%S].
+msg.dccaccept.add       = Now auto-accepting DCC on this network from %S.
+msg.dccaccept.del       = No longer auto-accepting DCC on this network from %S.
+msg.dccaccept.adderr    = You are already auto-accepting DCC on this network from %S.
+msg.dccaccept.delerr    = %S not found on your DCC auto-accept list for this network.
+
+msg.dcc.command.accept  = [[Accept][Accept this DCC offer][%S]]
+msg.dcc.command.decline = [[Decline][Decline (refuse) this DCC offer][%S]]
+msg.dcc.command.cancel  = [[Cancel][Cancels this DCC offer][%S]]
+msg.dcc.command.close   = [[Close][Close (disconnect) this DCC offer][%S]]
+
+# DCC state names.
+msg.dcc.state.abort      = Aborted
+msg.dcc.state.request    = Requested
+msg.dcc.state.accept     = Accepted
+msg.dcc.state.connect    = Connected
+# 1 = percent, 2 = current pos, 3 = total size, 4 = speed.
+msg.dcc.state.connectPro = Connected (%S%% complete, %S of %S, %S)
+msg.dcc.state.disconnect = Done
+msg.dcc.state.decline    = Declined
+msg.dcc.state.fail       = Failed
+
+# SI general format (1$ == number, 2$ == scale suffix).
+msg.si.size  = %1$S %2$S
+msg.si.speed = %1$S %2$S
+
+# SI suffixes for sizes.
+msg.si.size.0 = B
+msg.si.size.1 = KiB
+msg.si.size.2 = MiB
+msg.si.size.3 = GiB
+msg.si.size.4 = TiB
+msg.si.size.5 = PiB
+msg.si.size.6 = EiB
+
+# SI suffixes for speeds.
+msg.si.speed.0 = B/s
+msg.si.speed.1 = KiB/s
+msg.si.speed.2 = MiB/s
+msg.si.speed.3 = GiB/s
+msg.si.speed.4 = TiB/s
+msg.si.speed.5 = PiB/s
+msg.si.speed.6 = EiB/s
+
+msg.ident.server.not.possible = Ident Server is unavailable in this version of &brandShortName; - the feature "scriptable server sockets" is missing. Mozilla builds after 2003-11-15 should contain this feature (e.g. Mozilla 1.6 or later).
+msg.ident.error               = Error enabling Ident Server: %S"
+
+msg.host.password = Enter a password for the server %S:
+msg.url.key       = Enter key for url %S:
+
+msg.startup.added    = <%1$S> will now open at startup.
+msg.startup.removed  = <%1$S> will no longer open at startup.
+msg.startup.exists   = <%1$S> is currently opened at startup.
+msg.startup.notfound = <%1$S> is not currently opened at startup.
+
+msg.test.hello   = Sample HELLO message, <http://testurl.com/foo.html>.
+msg.test.info    = Sample INFO message, <http://testurl.com/foo.html>.
+msg.test.error   = Sample ERROR message, <http://testurl.com/foo.html>.
+msg.test.help    = Sample HELP message, <http://testurl.com/foo.html>.
+msg.test.usage   = Sample USAGE message, <http://testurl.com/foo.html>.
+msg.test.status  = Sample STATUS message, <http://testurl.com/foo.html>.
+msg.test.privmsg = Normal message from %S to %S, <http://testurl.com/foo.html>.
+msg.test.action  = Action message from %S to %S, <http://testurl.com/foo.html>.
+msg.test.notice  = Notice message from %S to %S, <http://testurl.com/foo.html>.
+msg.test.url     = Sample URL <http://www.mozilla.org> message.
+msg.test.styles  = Sample text styles *bold*, _underline_, /italic/, |teletype| message.
+msg.test.emoticon = Sample emoticon :) :( :~( :0 :/ :P :| (* message.
+msg.test.rheet   = Sample Rheeeeeeeeeet! message.
+msg.test.topic   = Sample Topic message, <http://testurl.com/foo.html>.
+msg.test.join    = Sample Join message, <http://testurl.com/foo.html>.
+msg.test.part    = Sample Part message, <http://testurl.com/foo.html>.
+msg.test.kick    = Sample Kick message, <http://testurl.com/foo.html>.
+msg.test.quit    = Sample Quit message, <http://testurl.com/foo.html>.
+msg.test.stalk   = "%S : Sample /stalk match, <http://testurl.com/foo.html>.
+msg.test.ctlchr  = Sample control char >%01<\\1 -- >%05<\\5 -- >%10<\\10
+msg.test.color   = Sample color %033c%034o%034l%033o%033r%034%20%036t%036e%032s%034t%0f message.
+msg.test.quote   = Sample ``double quote'' message.
+
+msg.welcome     = Welcome to Ambassador…\nBelow is a short selection of information to help you get started using Ambassador.
+msg.welcome.url = Because Ambassador was launched from a URL, the target has been opened for you. You can find it on the tab bar, next to this view.
+msg.tabdnd.drop = Would you like to use the file ``%S'' as your new motif?
+msg.default.status = Welcome to Ambassador!
+
+msg.closing = Disconnecting from IRC.  Click close again to exit now.
+msg.confirm.quit = You are still connected to some networks, are you sure you want to quit Ambassador?\nConfirming will close the window, and disconnect from all the networks and channels you're connected to.
+msg.quit.anyway  = &Quit Anyway
+msg.dont.quit    = &Don't Quit
+msg.warn.on.exit = Warn me when quitting while still connected
+
+msg.login.confirm          = Do you want to save the password for ``%S''?
+msg.login.prompt           = Prompt to save passwords
+msg.login.save             = Yes
+msg.login.dont             = No
+msg.login.added            = Saved password for ``%S''.
+msg.login.updated          = Changed password for ``%S''.
+msg.login.err.unknown.type = Unknown login type ``%S''.
+
+msg.whois.name     = "%S <%S@%S> ``%S''
+msg.whois.channels = "%S: member of %S"
+msg.whois.server   = "%S: attached to %S ``%S''
+msg.whois.idle     = "%S: idle for %S (on since %S)
+msg.whois.away     = "%S: away with message ``%S''
+msg.whois.end      = End of WHOIS information for %S.
+
+msg.ignore.list.1  = Currently not ignoring anyone.
+msg.ignore.list.2  = Currently ignoring [%S].
+msg.ignore.add     = You are now ignoring %S.
+msg.ignore.adderr  = You are already ignoring %S.
+msg.ignore.del     = You are no longer ignoring %S.
+msg.ignore.delerr  = "%S not found in your ignore list.
+
+msg.you.invite     = You have invited %S to %S.
+msg.invite.you     = "%S (%S@%S) has invited you to [[%S][Accept invitation to channel %S][goto-url %S]].
+
+msg.nick.in.use    = The nickname ``%S'' is already in use, use the /nick command to pick a new one.
+msg.retry.nick     = The nickname ``%S'' is already in use, trying ``%S''.
+msg.nick.prompt    = Enter a nickname to use:
+
+msg.tab.name.prompt = Enter a label for this tab:
+
+msg.list.rerouted  = List reply will appear on the ``%S'' view.
+msg.list.end       = Displayed %S of %S channels.
+msg.list.chancount = This server has %S channels. Listing them all will probably take a long time, and may lead to Ambassador becoming unresponsive or being disconnected by the server. [[List Channels][List all channels][%S]]
+
+msg.who.end        = End of WHO results for ``%S'', %S user(s) found.
+msg.who.match      = User %S, (%S@%S) ``%S'' (%S), member of %S, is connected to <irc://%S/>, %S hop(s).
+
+msg.connection.attempt = Connecting to %S (%S)… [[Cancel][Cancel connecting to %S][%S]]
+msg.connection.refused = Connection to %S (%S) refused. [[Help][Get more information about this error online][faq connection.refused]]
+msg.connection.abort.offline = The connection to %S (%S) was aborted because you went into offline mode.
+msg.connection.abort.unknown = The connection to %S (%S) was aborted with error %S.
+msg.connection.timeout = Connection to %S (%S) timed out. [[Help][Get more information about this error online][faq connection.timeout]]
+msg.unknown.host       = Unknown host ``%S'' connecting to %S (%S). [[Help][Get more information about this error online][faq connection.unknown.host]]
+msg.invalid.cert       = "%S has an invalid security certificate. If you trust this server, [[add an exception][Opens the dialog to add a security certificate exception][%S]].
+msg.connection.closed  = Connection to %S (%S) closed. [[Help][Get more information about this error online][faq connection.closed]]
+msg.connection.reset   = Connection to %S (%S) reset. [[Help][Get more information about this error online][faq connection.reset]]
+msg.connection.quit    = Disconnected from %S (%S). [[Reconnect][Reconnect to %S][%S]]
+msg.close.status       = Connection to %S (%S) closed with status %S.
+
+msg.proxy.connection.refused = The proxy server you configured is refusing the connection.
+msg.unknown.proxy.host       = Unknown proxy host connecting to %S (%S).
+
+# In these messages, the first replacement string is a connection error from above.
+msg.connection.exhausted   = "%S Connection attempts exhausted, giving up.
+msg.reconnecting.in        = "%S Reconnecting in %S. [[Cancel][Cancel reconnecting to %S][%S]]
+msg.reconnecting.in.left   = "%S %S attempts left, reconnecting in %S. [[Cancel][Cancel reconnecting to %S][%S]]
+msg.reconnecting.in.left1  = "%S 1 attempt left, reconnecting in %S. [[Cancel][Cancel reconnecting to %S][%S]]
+
+msg.reconnecting           = Reconnecting…
+msg.confirm.disconnect.all = Are you sure you want to disconnect from ALL networks?
+msg.no.connected.nets      = You are not connected to any networks.
+msg.no.reconnectable.nets  = There are no networks to reconnect to.
+
+msg.ping.reply         = Ping reply from %S in %S.
+msg.ping.reply.invalid = Malformed ping reply from %S.
+msg.prefix.response    = "%S, your result is,
+
+msg.topic.changed = "%S has changed the topic to ``%S''
+msg.topic         = Topic for %S is ``%S''
+msg.no.topic      = No topic for channel %S"
+msg.topic.date    = Topic for %S was set by %S on %S"
+
+msg.you.joined      = YOU (%S) have joined %S"
+msg.someone.joined  = "%S (%S@%S) has joined %S"
+msg.you.left        = YOU (%S) have left %S"
+msg.you.left.reason = YOU (%S) have left %S (%S)
+msg.someone.left    = "%S has left %S"
+msg.someone.left.reason = "%S has left %S (%S)
+msg.youre.gone      = YOU (%S) have been booted from %S by %S (%S)
+msg.someone.gone    = "%S was booted from %S by %S (%S)
+
+msg.mode.all        = Mode for %S is %S"
+msg.mode.changed    = Mode %S by %S"
+
+msg.flushssl.success = Flushed SSL session cache.
+
+msg.away.on      = You are now marked as away (%S). Click the nickname button or use the |/back| command to return from being away.
+msg.idle.away.on = You have automatically been marked as away (%S) after %S minutes of inactivity.
+msg.away.off     = You are no longer marked as away.
+msg.away.prompt  = Enter an away message to use:
+msg.away.default = I'm not here right now.
+msg.away.idle.default = I'm not here right now.
+
+msg.you.quit     = YOU (%S) have left %S (%S)
+msg.someone.quit = "%S has left %S (%S)
+
+msg.unknown.ctcp = Unknown CTCP %S (%S) from %S"
+
+msg.fonts.family.fmt   = Font family is ``%S''
+msg.fonts.family.pick  = Enter the font family you wish to use:
+msg.fonts.size.fmt     = Font size is %Spt
+msg.fonts.size.default = Font size is default
+msg.fonts.size.pick    = Enter the font size you wish to use. Note: Non-numeric inputs will result in the default size.
+
+msg.supports.chanTypes = Supported channel types: %S"
+msg.supports.chanModesA = Supported channel modes (A: lists): %S"
+msg.supports.chanModesB = Supported channel modes (B: param): %S"
+msg.supports.chanModesC = Supported channel modes (C: on-param): %S"
+msg.supports.chanModesD = Supported channel modes (D: boolean): %S"
+msg.supports.userMode = "%S (%S)
+msg.supports.userModes = Supported channel user modes: %S"
+msg.supports.flagsOn = This server DOES support: %S"
+msg.supports.flagsOff = This server DOESN'T support: %S"
+msg.supports.miscOption = "%S=%S"
+msg.supports.miscOptions = Server settings/limits: %S"
+msg.supports.caps = Supported capabilities: %S"
+msg.supports.capsOn = Enabled capabilities: %S"
+
+msg.caps.on = Capability %S enabled.
+msg.caps.off = Capability %S disabled.
+msg.caps.error = Capability %S is invalid.
+
+msg.conf.mode.on     = Conference Mode has been enabled for this view; joins, leaves, quits and nickname changes will be hidden.
+msg.conf.mode.stayon = Conference Mode is enabled for this view; joins, leaves, quits and nickname changes are hidden.
+msg.conf.mode.off    = Conference Mode has been disabled for this view; joins, leaves, quits and nickname changes will be shown.
+
+# Join Network/Channel dialog
+msg.cd.updated    = Network's channel list cached on %S"
+msg.cd.updated.format = %e %B %Y
+msg.cd.updated.never = Network's channel list not cached
+msg.cd.create     = <create new channel>
+msg.cd.filtering  = Filtered %S of %S channels…
+msg.cd.showing    = Showing %S of %S channels.
+msg.cd.wait.list  = Waiting for current list operation to finish…
+msg.cd.fetching   = Fetching channel list…
+msg.cd.fetched    = Fetched %S channels…
+msg.cd.error.list = There was an error loading the channel list.
+msg.cd.loaded     = Loaded %S channels…
+
+
+msg.urls.none   = There are no stored URLs.
+msg.urls.header = Listing the %S most recent stored URLs (most recent first):
+msg.urls.item   = URL %S: %S"
+
+msg.save.completeview         = View, Complete
+msg.save.htmlonlyview         = View, HTML Only
+msg.save.plaintextview        = View, Plain Text
+msg.save.files.folder         = %S_files
+msg.save.dialogtitle          = Save View ``%S'' As…
+msg.save.err.no.ext           = You must specify either a normal extension or <savetype>. Nothing was saved.
+msg.save.err.invalid.path     = The path ``%S'' is not a valid path or URL to save to. Only local file paths and file:/// urls are accepted.
+msg.save.err.invalid.ext      = The extension ``%S'' cannot be used without supplying a <savetype>. Use either |.xhtml|, |.xhtm|, |.html|, |.htm| or |.txt| as a file extension, or supply <savetype>.
+msg.save.err.invalid.savetype = The savetype ``%S'' is not a valid type of file to save to. Use either |complete|, |htmlonly| or |text|.
+msg.save.err.failed           = Saving the view ``%1$S'' to ``%2$S'' failed:\n ``%3$S''
+msg.save.fileexists           = The file ``%S'' already exists.\n Click OK to overwrite it, click Cancel to keep the original file.
+msg.save.successful           = The view ``%1$S'' has been saved to <%2$S>.
+
+# Plugin installation
+msg.install.plugin.err.download     = An error occurred downloading the plugin: %S"
+msg.install.plugin.err.remove.temp  = An error occurred removing the temporary files: %S"
+msg.install.plugin.err.no.name      = Unable to pick a plugin name from the source, please specify one instead.
+msg.install.plugin.err.protocol     = Sorry, the source location has been specified with an unknown protocol. Only 'file', 'http' and 'https' are supported.
+msg.install.plugin.err.install.to   = Unable to find a suitable install location (initialScripts). Please fix the initialScripts preference, for example by resetting it, using the command: |/pref initialScripts - |. Careful, this will remove any plugin you installed elsewhere from this list!
+msg.install.plugin.err.check.sd     = An error occurred checking the source and destination: %S"
+msg.install.plugin.err.many.initjs  = This Ambassador plugin appears to have multiple 'init.js' files and thus cannot be installed.
+msg.install.plugin.err.mixed.base   = This Ambassador plugin has a base path for 'init.js' which is not used for all other files. This plugin will probably not function in this state.
+msg.install.plugin.err.already.inst = This Ambassador plugin appears to already be installed.
+msg.install.plugin.err.extract      = An error occurred extracting the compressed source: %S"
+msg.install.plugin.err.installing   = An error occurred installing the source: %S"
+msg.install.plugin.err.format       = The source specified is not a format understood by the plugin installer.
+msg.install.plugin.err.removing     = An error occurred loading or enabling the plugin. Removing the plugin.
+msg.install.plugin.err.spec.name    = The plugin name must be specified!
+
+msg.install.plugin.select.source    = Select a script to install…
+
+msg.install.plugin.warn.name        = Changed plugin name for install from '%S' to '%S' to match source code.
+msg.install.plugin.downloading      = Downloading plugin from '%S'…
+msg.install.plugin.installing       = Installing from '%S' to '%S'…
+msg.install.plugin.done             = Done. Ambassador plugin '%S' installed!
+
+# SSL Connection info dialog
+msg.security.broken             = Broken Encryption
+msg.security.insecure           = No Encryption
+msg.security.weak               = Secured with Weak Encryption
+msg.security.strong             = Secured with Strong Encryption
+msg.transparency.none           = This server does not supply Certificate Transparency audit records.
+msg.transparency.ok             = This server supplies publicly auditable Certificate Transparency records.
+msg.transparency.unknownlog     = This server claims to have Certificate Transparency audit records, but the records were issued by an unknown party and cannot be verified.
+msg.transparency.invalid        = This server supplies Certificate Transparency audit records, but the records failed verification.
+ 
+# Networks editor dialog
+msg.networks.fmt.header          = "%S"
+msg.networks.fmt.display.network = Network %S"
+msg.networks.fmt.display.server  = Network %S, server %S"
+msg.networks.default             = Networks
+
+msg.networks.err.save = An exception occurred trying to save the networks list: %S.
+
+msg.networks.add     = Enter item to add:
+msg.networks.delete  = Are you sure you want to remove the item ``%S''?
+msg.networks.restore = Are you sure you want to restore the default network list, and overwrite any changes you have made?
+
+# Munger
+munger.mailto=Mailto
+munger.link=URLs
+munger.channel-link=IRC channel
+munger.bugzilla-link=Bugzilla link
+munger.face=Face
+munger.ear=Ear
+munger.quote=Double Quotes
+munger.rheet=Rheet
+munger.bold=Bold
+munger.italic=Italic
+munger.talkback-link=Talkback link
+munger.teletype=Teletype
+munger.underline=Underline
+munger.ctrl-char=Control Chars
+
+
+# Date/Time representations for strftime
+
+datetime.day.long    = Sunday^Monday^Tuesday^Wednesday^Thursday^Friday^Saturday
+datetime.day.short   = Sun^Mon^Tue^Wed^Thu^Fri^Sat
+datetime.month.long  = January^February^March^April^May^June^July^August^September^October^November^December
+datetime.month.short = Jan^Feb^Mar^Apr^May^Jun^Jul^Aug^Sep^Oct^Nov^Dec
+
+datetime.uam = AM
+datetime.lam = am
+datetime.upm = PM
+datetime.lpm = pm
+
+datetime.presets.lc = %Y-%m-%d %H:%M:%S
+datetime.presets.lr = %I:%M:%S %p
+datetime.presets.lx = %Y-%m-%d
+datetime.presets.ux = %H:%M:%S
+
+
+# Messages used in config.js, part of the pref window.
+
+# We only allow one pref window open at once, this occurs when a 2nd is opened.
+msg.prefs.alreadyOpen  = Ambassador's preferences are already open; you may not open a second copy.
+
+msg.prefs.err.save = An exception occurred trying to save the preferences: %S.
+
+msg.prefs.browse       = Browse…
+msg.prefs.browse.title = Ambassador Browse
+msg.prefs.move.up      = Move up
+msg.prefs.move.down    = Move down
+msg.prefs.add          = Add…
+msg.prefs.edit         = Edit
+msg.prefs.delete       = Delete
+
+msg.prefs.list.add     = Enter item to add:
+msg.prefs.list.edit    = Edit the item as needed:
+msg.prefs.list.delete  = Are you sure you want to remove the item ``%S''?
+
+msg.prefs.object.delete = Are you sure you want to remove the object ``%S'' and all its preferences?
+msg.prefs.object.reset  = Are you sure you want to reset all the preferences for ``%S'' to their defaults?
+
+# First is for adding prefix/suffix to the overall header, and the next three
+# are for the different objects (first is network name, second is channel/user
+# name).
+msg.prefs.fmt.header          = "%S"
+msg.prefs.fmt.display.network = Network %S"
+msg.prefs.fmt.display.channel = Network %S, channel %S"
+msg.prefs.fmt.display.user    = Network %S, user %S"
+
+# Name for "global" object.
+msg.prefs.global              = Global Settings
+
+# Localized names for all the prefs and tooltip "help" messages.
+# NOTE: "Bugzilla", "Ambassador" and "mIRC" are product names.
+pref.activityFlashDelay.label   = Activity flash delay
+pref.activityFlashDelay.help    = When a tab that has had activity gets more activity, the tab is flashed. This preference is the length of the flash in milliseconds: 0 disables it.
+pref.alert.globalEnabled.label  = Globally enabled
+pref.alert.globalEnabled.help   = When enabled, all alerts configured may be shown. When disabled, no alerts will be shown. Provides nothing more than a global toggle.
+pref.alert.enabled.label        = Enabled
+pref.alert.enabled.help         = When enabled, popups are shown for this view.
+pref.alert.nonFocusedOnly.label = Only when window not active
+pref.alert.nonFocusedOnly.help  = When enabled, all message notifications are suppressed when the window is active. Otherwise, message notifications for non-active views will be shown. Unchecking is suggested for channel moderators or for low traffic channels.
+pref.alert.channel.event.label  = Alert for Channel Event
+pref.alert.channel.event.help   = Shows message notifications for joins, parts, kicks, usermodes, and any other system messages. Suggested for channel moderators or for low traffic channels.
+pref.alert.channel.chat.label   = Alert for Channel Chat
+pref.alert.channel.chat.help    = Show message notifications for normal chat messages. It may be annoying for high traffic channels. Suggested for moderators or for low traffic channels.
+pref.alert.channel.stalk.label  = Alert for Channel Stalk
+pref.alert.channel.stalk.help   = Shows message notifications for messages containing stalk words.
+pref.alert.user.chat.label      = Alert for User Chat
+pref.alert.user.chat.help       = Shows message notifications for private messages.
+pref.aliases.label              = Command aliases
+pref.aliases.help               = Allows you to make shortcuts to various commands or sequences of commands. Each item is of the form "<name> = <command-list>". The command-list is a list of commands (without the leading "/") along with their parameters, each separated by ";". The name of the alias will automatically be turned into a command when Ambassador starts.
+pref.autoAwayCap.label          = Auto away-check user limit
+pref.autoAwayCap.help           = Ambassador automatically checks which users are here and which are away in each channel you are a member of, however, this causes significant lag on larger channels. Any channel bigger than this limit won't be checked.
+pref.autoAwayPeriod.label       = Auto away-check period length
+pref.autoAwayPeriod.help        = Ambassador automatically checks which users are here and which are away in each channel you are a member of. This specifies how many minutes should pass between checks. Checking is automatically disabled if the server supports the "away-notify" extension.
+pref.autoRejoin.label           = Rejoin when kicked
+pref.autoRejoin.help            = If this is turned on, Ambassador will try (only once) to rejoin a channel you got kicked from. Note, some channels dislike auto-rejoin, and will ban you, so be careful.
+pref.away.label                 = Away status
+pref.away.help                  =
+pref.awayIdleTime.label         = Auto-away timeout
+pref.awayIdleTime.help          = After how many minutes of inactivity Ambassador will set your status to "away". Set to 0 to disable it.
+pref.awayIdleMsg.label          = Auto-away message
+pref.awayIdleMsg.help           = The away message Ambassador will use when you go away.
+pref.awayNick.label             = Nickname (away)
+pref.awayNick.help              = This nickname will automatically be used when you mark yourself away, if different from 'Nickname'. You may leave this blank to not change nickname when going away.
+pref.bugKeyword.label           = Bug Keywords
+pref.bugKeyword.help            = You can define multiple issue tracker keywords as a regular expression perhaps by separating them with "|" e.g. bug|issue|case|ticket
+pref.bugURL.label               = Bugzilla URL
+pref.bugURL.help                = The URL used for links to bugs. "%s" is replaced with the bug number or alias. The text "bug " followed by a number or "#" and a 1-20 letter word (bug alias) will get turned into a link using this URL.
+pref.bugURL.comment.label       = Bugzilla URL for Comments
+pref.bugURL.comment.help        = The URL or suffix used for links to specific comments within bugs. With a full URL, "%1$s" is replaced with the bug number or alias and "%2$s" with the comment number, respectively. With a suffix, "%s" is replaced with the comment number. The text "bug " followed by a number or "#" and a 1-20 letter word (bug alias) followed by " comment " followed by another number will get turned into a link using this URL or suffix.
+pref.charset.label              = Character encoding
+pref.charset.help               = For multiple clients to correctly read messages with non-ASCII characters on IRC, they need to use the same character encoding.
+pref.collapseMsgs.label         = Collapse messages
+pref.collapseMsgs.help          = Makes multiple messages from one person only show their nickname against the first, which can look cleaner than having the nickname repeated.
+pref.collapseActions.label      = Collapse actions when collapsing messages
+pref.collapseActions.help       = Makes multiple actions from one person only show their nickname against the first, which can look cleaner than having the nickname repeated.
+pref.conference.limit.label     = Conference mode limit
+pref.conference.limit.help      = When the number of users in a channel sufficiently exceeds this limit, Ambassador switches the channel into "conference mode", during which JOIN, PART, QUIT and NICK messages for other users are hidden. When the user count drops sufficiently below the limit, normal operation is resumed automatically. Setting this to 0 will never use conference mode, likewise setting this to 1 will always use it.
+pref.connectTries.label         = Connection attempts
+pref.connectTries.help          = The number of times Ambassador attempts to connect to a server or network. Set to -1 for unlimited attempts.
+pref.copyMessages.label         = Copy important messages
+pref.copyMessages.help          = Any message marked as "important" will be copied to the network view. It allows you to quickly see messages that were addressed to you when you were away from the computer.
+pref.dcc.enabled.label          = DCC Enabled
+pref.dcc.enabled.help           = When disabled, no DCC-related commands will do anything, and all DCC requests from other users will be ignored.
+pref.dcc.autoAccept.list.label  = Auto-accept list
+pref.dcc.autoAccept.list.help   = List of nicknames to automatically accept DCC chat/file offers from. Hostmasks are also accepted, using "*" as a wildcard. If this list is empty, all DCC requests must be manually accepted or declined.
+pref.dcc.downloadsFolder.label  = Downloads folder
+pref.dcc.downloadsFolder.help   = Specifies the default destination for files received via DCC.
+pref.dcc.listenPorts.label      = Listen Ports
+pref.dcc.listenPorts.help       = List of ports that other users can connect to remotely. Each item may be a single port number, or a range specified as "lower-upper". Leave empty to use a random, OS-picked port. Each time you offer a DCC connection to someone, the next port listed is picked.
+pref.dcc.useServerIP.label      = Get local IP from server
+pref.dcc.useServerIP.help       = When turned on, Ambassador will ask the server for your IP address when connecting. This allows DCC to obtain the correct IP address when operating behind a gateway or NAT-based system.
+pref.debugMode.label            = Debug mode
+pref.debugMode.help             = This preference is for debugging Ambassador and can generate a lot of debug output (usually to the console). It is a list of letters, signifying what you want debug messages about. "c" for context menus (dumps data when opening a context menu), "d" for dispatch (dumps data when dispatching commands), and "t" for trace/hook (dumps data about hooks and the event queue processing) debugging.
+pref.defaultQuitMsg.label       = Default quit message
+pref.defaultQuitMsg.help        = Specifies a default quit message to use when one is not explicitly specified. Leave blank to use the basic Ambassador one, which simply states what version you have.
+pref.desc.label                 = Description
+pref.desc.help                  = Sets the "description" (aka "real name") field shown in your /whois information. It is commonly used to include one's real name, but you are not required to enter anything.
+pref.deleteOnPart.label         = Delete channel views on part
+pref.deleteOnPart.help          = Causes /leave and /part to also close the channel view.
+pref.displayHeader.label        = Show header
+pref.displayHeader.help         = Display the chat header on this view. This contains information like the URL of the current view, and the topic and modes for a channel view.
+pref.font.family.label          = Font Family
+pref.font.family.help           = Selects the font in which Ambassador will display messages. The value "default" will use your global font family; "serif", "sans-serif" and "monospace" will use your global font settings; other values will be treated as font names.
+pref.font.size.label            = Font Size (pt)
+pref.font.size.help             = Selects the integer font size you want Ambassador to display messages with. The value 0 will use your global font size, and other integer values will be interpreted as the size in points (pt).
+pref.guessCommands.label        = Guess unknown commands
+pref.guessCommands.help         = If you enter a command (starts with "/") that Ambassador doesn't understand, then it can try "guessing" by sending the command to the server. You can turn this off if you don't want Ambassador to try this.
+pref.hasPrefs.label             = Object has prefs
+pref.hasPrefs.help              = Indicates the object has preferences saved. Never shown in preferences window. :)
+pref.identd.enabled.label       = Enable Identification Server during connection process
+pref.identd.enabled.help        = Allows Ambassador to connect to servers that require an ident response.
+pref.initialURLs.label          = Locations
+pref.initialURLs.help           = A list of locations (irc: and ircs: URLs) to which Ambassador should connect when starting. These will not be processed if Ambassador was started by clicking on a hyperlink.
+pref.initialScripts.label       = Script files
+pref.initialScripts.help        = A list of script files (file: URLs) for Ambassador to load when it starts. URLs may be relative to the profile directory. If a URL points to a directory, "init.js" from that directory and each subdirectory is loaded.
+pref.inputSpellcheck.label      = Spellcheck the inputbox
+pref.inputSpellcheck.help       = Whether or not the inputbox will be spellchecked. Only works on recent &brandShortName; builds.
+pref.link.focus.label           = Focus browser when opening links
+pref.link.focus.help            = Moves the focus to the browser window when opening URLs from Ambassador.
+pref.log.label                  = Log this view
+pref.log.help                   = Makes Ambassador log this view. The log file is usually stored in your profile, which can be overridden with "Profile path" (for the base path) or "Log file name" for a specific view's log.
+pref.logFileName.label          = Log file name
+pref.logFileName.help           = The log file used for this view. If the view is currently open and logging, changing this option won't take effect until the next time it starts logging.
+pref.logFile.client.label       = Log file for client
+pref.logFile.client.help        = Specifies the name of the log file for the client view. This is appended to the 'log folder' to create a full path.
+pref.logFile.network.label      = Log file for networks
+pref.logFile.network.help       = Specifies the name of the log file for network views. This is appended to the 'log folder' to create a full path.
+pref.logFile.channel.label      = Log file for channels
+pref.logFile.channel.help       = Specifies the name of the log file for channel views. This is appended to the 'log folder' to create a full path.
+pref.logFile.user.label         = Log file for users
+pref.logFile.user.help          = Specifies the name of the log file for user/query views. This is appended to the 'log folder' to create a full path.
+pref.logFile.dccuser.label      = Log file for DCC
+pref.logFile.dccuser.help       = Specifies the name of the log file for DCC chat/file views. This is appended to the 'log folder' to create a full path.
+pref.logFolder.label            = Log folder
+pref.logFolder.help             = Specifies the base location for all logs. The various "Log file for" preferences specify the exact names for the different types of log file.
+pref.login.promptToSave.label   = Prompt to save passwords
+pref.login.promptToSave.help    = Enable this preference if you wish to save passwords with the password manager. Passwords that can be saved include server passwords, channel keys, nickname identification passwords and oper passwords. Passwords can only be added via this prompt.
+pref.messages.click.label       = Normal click
+pref.messages.click.help        = What to do when clicking a URL normally.
+pref.messages.ctrlClick.label   = Control-click
+pref.messages.ctrlClick.help    = What to do when clicking a URL with the Control key held down.
+pref.messages.metaClick.label   = Alt/Meta-click
+pref.messages.metaClick.help    = What to do when clicking a URL with the Alt or Meta key held down.
+pref.messages.middleClick.label = Middle-click
+pref.messages.middleClick.help  = What to do when clicking a URL with the middle mouse button.
+pref.motif.dark.label           = Dark motif
+pref.motif.dark.help            = The dark motif selectable from the View > Color Scheme menu.
+pref.motif.light.label          = Light motif
+pref.motif.light.help           = The light motif selectable from the View > Color Scheme menu.
+pref.motif.current.label        = Current motif
+pref.motif.current.help         = The currently selected motif file. A Motif is a CSS file that describes how do display the chat view, and can be used to customize the display.
+pref.multiline.label            = Multiline input mode
+pref.multiline.help             = Sets whether Ambassador is using the multiline input box or the single-line one.
+pref.munger.bold.label          = Bold
+pref.munger.bold.help           = Makes Ambassador display text between astersks (e.g. *bold*) in an actually bold face.
+pref.munger.bugzilla-link.label = Bugzilla links
+pref.munger.bugzilla-link.help  = Makes Ambassador hyperlink "bug <number>" to the specified bug, using the "Bugzilla URL" as the base link.
+pref.munger.channel-link.label  = Channel links
+pref.munger.channel-link.help   = Makes Ambassador convert "#channel" into a link to the channel.
+pref.munger.colorCodes.label    = mIRC colors
+pref.munger.colorCodes.help     = Enables the display of colors on the chat text, as well as other mIRC codes (bold and underline). When disabled, Ambassador will simply hide mIRC codes.
+pref.munger.ctrl-char.label     = Control characters
+pref.munger.ctrl-char.help      = Makes Ambassador display control characters it doesn't understand.
+pref.munger.face.label          = Faces (emoticons)
+pref.munger.face.help           = Makes Ambassador display images for common smilies, such as :-) and ;-).
+pref.munger.italic.label        = Italic
+pref.munger.italic.help         = Makes Ambassador italicize text between forward slashes. (e.g. /italic/)
+pref.munger.link.label          = Web links
+pref.munger.link.help           = Makes Ambassador hyperlink text that looks like a URL.
+pref.munger.mailto.label        = Mail links
+pref.munger.mailto.help         = Makes Ambassador hyperlink text that looks like an e-mail address.
+pref.munger.quote.label         = Neater quotes
+pref.munger.quote.help          = Makes Ambassador replace `` with \u201C and '' with \u201D.
+pref.munger.rheet.label         = Rheet
+pref.munger.rheet.help          = Makes Ambassador hyperlink "rheet": a very Mozilla.org-centric feature.
+pref.munger.talkback-link.label = Talkback links
+pref.munger.talkback-link.help  = Makes Ambassador hyperlink "TB<numbers><character>" to the specified talkback stack trace.
+pref.munger.teletype.label      = Teletype
+pref.munger.teletype.help       = Makes Ambassador display |teletype| actually in teletype (a fixed-width font).
+pref.munger.underline.label     = Underline
+pref.munger.underline.help      = Makes Ambassador underline text between underscores. (e.g. _underline_)
+pref.munger.word-hyphenator.label = Hyphenate long words
+pref.munger.word-hyphenator.help  = Makes Ambassador insert "hyphenation points" into long words and URLs so they can wrap to the screen size.
+pref.newTabLimit.label          = Max auto-created views
+pref.newTabLimit.help           = Sets the number of views (such as query views) that may be created automatically by Ambassador. Once the limit is reached, private messages will show up on the current view instead. Set this to 0 for unlimited or 1 to disallow all auto-created views.
+pref.nickCompleteStr.label      = Nickname completion string
+pref.nickCompleteStr.help       = This string is appended to a nickname when tab-completed at the start of a line.
+pref.nickname.label             = Nickname
+pref.nickname.help              = This is the name seen by everyone else when on IRC. You can use anything you like, but it can't contain particularly "weird" characters, so keep to alpha-numeric characters.
+pref.nicknameList.label         = Nickname List
+pref.nicknameList.help          = This is a list of nicknames you want Ambassador to try if the one you were using happens to be already in use. Your normal nickname need not be listed.
+pref.notify.aggressive.label    = Aggressive notify
+pref.notify.aggressive.help     = When someone sends you a private message, says your nickname, or mentions one of your "stalk words", Ambassador considers the message to be worth getting your attention. This preference sets whether it's allowed to flash the window or bring it to the front (varies by OS) in order to get your attention.
+pref.notifyList.label           = Notify list
+pref.notifyList.help            = A list of nicknames to periodically check to see if they are on-line or not. Every 5 minutes, Ambassador will check this list, and inform you if anyone is now on-line or has gone off-line.
+pref.outgoing.colorCodes.label  = Enable sending color codes
+pref.outgoing.colorCodes.help   = Allows you to send color and other mIRC codes, such as bold and underline, using special %-sequences. When enabled, simply type "%" to see a popup of the various choices.
+pref.outputWindowURL.label      = Output Window
+pref.outputWindowURL.help       = You probably don't want to change this. The chat view loads this URL to display the actual messages, header, etc., and the file must correctly define certain items or you'll get JavaScript errors and a blank chat window!
+pref.profilePath.label          = Profile path
+pref.profilePath.help           = This is the base location for Ambassador-related files. By default, Ambassador loads scripts from the "scripts" subdirectory, and stores log files in the "logs" subdirectory.
+pref.proxy.typeOverride.label   = Proxy Type
+pref.proxy.typeOverride.help    = Override the normal proxy choice by specifying "http" to use your browser's HTTP Proxy or "none" to force no proxy to be used (not even the SOCKS proxy). Note that this usually only works when the browser is set to use a manual proxy configuration.
+pref.reconnect.label            = Reconnect when disconnected unexpectedly
+pref.reconnect.help             = When your connection is lost unexpectedly, Ambassador can automatically reconnect to the server for you.
+pref.websearch.url.label        = Web search URL
+pref.websearch.url.help         = The URL to use when running a web search; your search terms will be appended to this URL. You can include the optional parameter %s to insert your search terms in a specific part of the URL instead (e.g. "http://www.searchwebsite.com/search?q=%s"). If this field is left blank, your browser's search engine will be used (or DuckDuckGo, if Ambassador is not running as a browser plugin).
+pref.showModeSymbols.label      = Show user mode symbols
+pref.showModeSymbols.help       = The userlist can either show mode symbols ("@" for op, "%" for half-op, "+" for voice), or it can show colored dots (green for op, dark blue for half-op, cyan for voice, and black for normal). Turn this preference on to show mode symbols instead of colored dots.
+pref.sortUsersByMode.label      = Sort users by mode
+pref.sortUsersByMode.help       = Causes the userlist to be sorted by mode, op first, then half-op (if supported on the server), then voice, followed by everyone else.
+pref.sound.enabled.label        = Enabled
+pref.sound.enabled.help         = Tick this preference to allow sound, or untick to turn off all sounds. Provides nothing more than a global toggle.
+pref.sound.overlapDelay.label   = Overlap Delay
+pref.sound.overlapDelay.help    = Sets the period of time during which the same event will not trigger the sound to be played. For example, the default value of 2000ms (2 seconds) means if two stalk matches occur within 2 seconds of each other, only the first will cause the sound to be played.
+##pref.sound.surpressActive.label = Suppress Sounds for active view
+##pref.sound.surpressActive.help  = Stops sounds generated by the active view from playing if Ambassador is the active window. Sounds from other views, or when Ambassador is not active, will always play.
+pref.sound.channel.start.label  = Sound for Channel Start
+pref.sound.channel.start.help   =
+pref.sound.channel.event.label  = Sound for Channel Event
+pref.sound.channel.event.help   =
+pref.sound.channel.chat.label   = Sound for Channel Chat
+pref.sound.channel.chat.help    =
+pref.sound.channel.stalk.label  = Sound for Channel Stalk
+pref.sound.channel.stalk.help   =
+pref.sound.user.start.label     = Sound for User Start
+pref.sound.user.start.help      =
+pref.sound.user.stalk.label     = Sound for User Chat
+pref.sound.user.stalk.help      =
+pref.stalkWholeWords.label      = Stalk whole words only
+pref.stalkWholeWords.help       = This preferences toggles Ambassador's handling of stalk words between finding matching words, or simple substrings. For example, "JavaScript is cool" will match the stalk word "script" only if this preferences is off.
+pref.stalkWords.label           = Stalk words
+pref.stalkWords.help            = A list of words that will cause a line to be marked "important" and will try to get your attention if "Aggressive notify" is turned on.
+pref.urls.store.max.label       = Max stored URLs
+pref.urls.store.max.help        = Sets the maximum number of URLs collected and stored by Ambassador. The "/urls" command displays the last 10 stored, or more if you do "/urls 20", for example.
+pref.userlistLeft.label         = Display the userlist on the left
+pref.userlistLeft.help          = Display the userlist on the left. Uncheck to display the userlist on the right instead.
+pref.username.label             = Username
+pref.username.help              = Your username is used to construct your "host mask", which is a string representing you. It includes your connection's host name and this username. It is sometimes used for setting auto-op, bans, and other things specific to one person.
+pref.usermode.label             = Usermode
+pref.usermode.help              = Your usermode is an option string that is sent to the IRC network. It is composed of a plus sign ("+") followed by one or more letters, each of which represents an option. The letter "i" represents "invisible mode". When you are invisible, your nickname will not appear in channel userlists for people who are not in the channel with you. The letter "s" allows you to see server messages like nickname collisions. For a more complete list of available options, look up usermode on www.irchelp.org.
+pref.warnOnClose.label          = Warn me when quitting while still connected
+pref.warnOnClose.help           = When quitting while still connected to networks, a message appears asking you if you are sure you want to quit. Uncheck this to disable it.
+
+# Preference group labels #
+
+pref.group.general.label               = General
+pref.group.general.connect.label       = Connection
+pref.group.general.ident.label         = Identification
+pref.group.general.log.label           = Logging
+pref.group.general.palert.label        = Message Notifications
+pref.group.global.palertconfig.label   = Message Notifications Configuration
+pref.group.appearance.label            = Appearance
+pref.group.appearance.misc.label       = Miscellaneous
+pref.group.appearance.motif.label      = Motifs
+pref.group.appearance.timestamps.label = Timestamps
+pref.group.appearance.timestamps.help  = The Format preference uses strftime replacements. For example, "%A %l:%M:%S%P" might become "Thursday 1:37:42pm".
+pref.group.appearance.userlist.label   = Userlist
+pref.group.dcc.label                   = DCC
+pref.group.dcc.ports.label             = Ports
+pref.group.dcc.autoAccept.label        = Auto-accept
+pref.group.munger.label                = Formatting
+pref.group.startup.label                = Startup
+pref.group.startup.initialURLs.label    = Locations
+pref.group.startup.initialScripts.label = Script files
+pref.group.lists.label                 = Lists
+pref.group.lists.stalkWords.label      = Stalk words
+pref.group.lists.aliases.label         = Command aliases
+pref.group.lists.notifyList.label      = Notify list
+pref.group.lists.nicknameList.label    = Nickname List
+pref.group.lists.autoperform.label     = Auto-perform
+pref.group.global.label                = Global
+pref.group.global.header.label         = Headers
+pref.group.global.header.help          = Sets the default visibility for headers of views. Each view can override this default if necessary.
+pref.group.global.links.label          = Links
+pref.group.global.links.help           = The link preferences define how Ambassador reacts to different kinds of clicks on links. You can re-arrange these to suit your preferences.
+pref.group.global.log.label            = Log these view types
+pref.group.global.log.help             = Sets the default logging state for views. Each view can override this default if necessary.
+pref.group.global.maxLines.label       = Scrollback size
+pref.group.global.maxLines.help        = The number of lines of text to keep in this view type. Once the limit is reached, the oldest lines are removed as new lines are added.
+pref.group.global.security.label       = Security
+pref.group.global.sounds.label         = Sound Configuration
+pref.group.general.sounds.help          =
+pref.group.general.soundEvts.label      = Sound Events
+pref.group.general.soundEvts.help       = Sounds for certain client events. These preferences are a space-separated list of either "beep" or file: URLs.
+
+# These are the prefs that get grouped #
+
+pref.autoperform.label          = Auto-perform
+pref.autoperform.help           = Enter any commands to be run when connecting to this network/joining this channel/opening this user's private chat. The commands are run in the order listed.
+pref.autoperform.channel.label  = Channel
+pref.autoperform.channel.help   = Enter any commands to be run when joining any channel.
+pref.autoperform.client.label   = Client
+pref.autoperform.client.help    = Enter any commands to be run when starting Ambassador.
+pref.autoperform.network.label  = Network
+pref.autoperform.network.help   = Enter any commands to be run when connecting to any network.
+pref.autoperform.user.label     = User
+pref.autoperform.user.help      = Enter any commands to be run when opening any user's private chat.
+
+pref.networkHeader.label        = Networks
+pref.networkHeader.help         =
+pref.channelHeader.label        = Channels
+pref.channelHeader.help         =
+pref.userHeader.label           = Users
+pref.userHeader.help            =
+pref.dccUserHeader.label        = DCC
+pref.dccUserHeader.help         =
+
+pref.networkLog.label           = Networks
+pref.networkLog.help            =
+pref.channelLog.label           = Channels
+pref.channelLog.help            =
+pref.userLog.label              = Users
+pref.userLog.help               =
+pref.dccUserLog.label           = DCC
+pref.dccUserLog.help            =
+
+pref.clientMaxLines.label       = Client
+pref.clientMaxLines.help        =
+pref.networkMaxLines.label      = Networks
+pref.networkMaxLines.help       =
+pref.channelMaxLines.label      = Channels
+pref.channelMaxLines.help       =
+pref.userMaxLines.label         = Users
+pref.userMaxLines.help          =
+pref.dccUserMaxLines.label      = DCC
+pref.dccUserMaxLines.help       =
+
+pref.timestamps.display.label   = Format
+pref.timestamps.display.help    =
+pref.timestamps.label           = Enabled
+pref.timestamps.help            =
+
+pref.msgBeep.label              = New query view
+pref.msgBeep.help               =
+pref.queryBeep.label            = Query message
+pref.queryBeep.help             =
+pref.stalkBeep.label            = Important message
+pref.stalkBeep.help             =

--- a/locales/nl-BE/chrome/ambassadorOverlay.dtd
+++ b/locales/nl-BE/chrome/ambassadorOverlay.dtd
@@ -1,0 +1,7 @@
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+
+<!ENTITY ircCmd.label		"IRC Chat">  
+<!ENTITY ircCmd.accesskey	"i">  
+<!ENTITY ircCmd.commandkey	"6">  

--- a/locales/nl-BE/chrome/browserOverlay.dtd
+++ b/locales/nl-BE/chrome/browserOverlay.dtd
@@ -1,0 +1,8 @@
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+
+<!ENTITY abButton.label   "Ambassador">
+  
+<!ENTITY abMenu.label     "Ambassador">
+<!ENTITY abMenu.accesskey "A">

--- a/locales/nl-BE/chrome/channels.dtd
+++ b/locales/nl-BE/chrome/channels.dtd
@@ -1,0 +1,33 @@
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+
+<!ENTITY window.title  "Verbinden met kanaal">
+
+<!ENTITY network.label     "Netwerk:">
+<!ENTITY network.accesskey "N">
+
+<!ENTITY channel.label     "Kanaal:">
+<!ENTITY channel.accesskey "K">
+
+<!ENTITY topics.label     "Zoek op topics of kanaalnamen">
+<!ENTITY topics.accesskey "t">
+
+<!ENTITY join.label     "Join">
+<!ENTITY join.accesskey "J">
+
+<!ENTITY minusers.label     "Min gebruikers:">
+<!ENTITY minusers.accesskey "M">
+
+<!ENTITY maxusers.label     "Max gebruikers:">
+<!ENTITY maxusers.accesskey "x">
+
+<!ENTITY refresh.label     "Nu verversen">
+<!ENTITY refresh.accesskey "">
+
+<!ENTITY network.hint.label "Geef een netwerk of servernaam in (een poort is optioneel) en een kanaal om verbinding mee te maken.">
+
+<!ENTITY col.network "Netwerk">
+<!ENTITY col.name  "Naam">
+<!ENTITY col.users "Gebruikers">
+<!ENTITY col.topic "Topic">

--- a/locales/nl-BE/chrome/config.dtd
+++ b/locales/nl-BE/chrome/config.dtd
@@ -1,0 +1,40 @@
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+
+<!ENTITY window.title  "Voorkeuren van Ambassador">
+
+<!ENTITY loading.label  "Even geduld, laden…">
+
+<!ENTITY homepage.url   "https://github.com/Ascrod/ambassador/">
+<!ENTITY homepage.label "Website van Ambassador">
+
+<!ENTITY object.add.label       "Toevoegen…">
+<!ENTITY object.add.hint        "Voeg een nieuw netwerk, kanaal of gebruiker toe om voorkeuren daarop in te stellen">
+<!ENTITY object.add.accesskey   "N">
+
+<!ENTITY object.del.label       "Verwijderen">
+<!ENTITY object.del.hint        "Verwijder het huidige object, inclusief de daarbijhorende voorkeuren">
+<!ENTITY object.del.accesskey   "V">
+
+<!ENTITY object.reset.label     "Herstellen">
+<!ENTITY object.reset.hint      "Herstel de voorkeuren van dit object naar de standaardwaarden">
+<!ENTITY object.reset.accesskey "H">
+
+<!ENTITY dialog.apply   "Toepassen">
+
+<!ENTITY network "Netwerk">
+<!ENTITY channel "Kanaal">
+<!ENTITY user    "Gebruiker">
+
+<!ENTITY config.add.title "Voeg voorkeurobject toe">
+
+<!ENTITY config.type.label        "Type:">
+<!ENTITY config.type.hint         "Het type object waarvoor je voorkeuren wilt toevoegen">
+<!ENTITY config.type.accesskey    "T">
+<!ENTITY config.network.label     "Netwerk:">
+<!ENTITY config.network.hint      "Gekende naam van het netwerk of de servernaam">
+<!ENTITY config.network.accesskey "N">
+<!ENTITY config.target.label      "Doel:">
+<!ENTITY config.target.hint       "Doelkanaal of gebruikersnaam">
+<!ENTITY config.target.accesskey  "D">

--- a/locales/nl-BE/chrome/install-plugin.dtd
+++ b/locales/nl-BE/chrome/install-plugin.dtd
@@ -1,0 +1,17 @@
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+
+<!ENTITY windowtitle                    "Plug-in installeren…">
+
+<!ENTITY name.label                     "Naam:">
+<!ENTITY name.accesskey                 "N">
+
+<!ENTITY name.autopick.label            "Automatisch een naam kiezen">
+<!ENTITY name.autopick.accesskey        "A">
+
+<!ENTITY source.label                   "Bron:">
+<!ENTITY source.accesskey               "R">
+
+<!ENTITY browse.label                   "Bladeren…">
+<!ENTITY browse.accesskey               "B">

--- a/locales/nl-BE/chrome/networks-list.dtd
+++ b/locales/nl-BE/chrome/networks-list.dtd
@@ -1,0 +1,28 @@
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+
+<!ENTITY window.title   "Netwerken">
+<!ENTITY dialog.restore "Standaardwaarden herstellen">
+
+<!ENTITY loading.label  "Even geduld, laden…">
+
+<!ENTITY object.network "Netwerk">
+<!ENTITY object.server  "Server">
+
+<!ENTITY object.name.label      "Naam">
+<!ENTITY object.name.help       "De name van het netwerk.">
+<!ENTITY object.hostname.label  "Hostnaam">
+<!ENTITY object.hostname.help   "Het adres van de server.">
+<!ENTITY object.port.label      "Poort">
+<!ENTITY object.port.help       "De poort om mee te verbinden.">
+<!ENTITY object.usessl.label    "Gebruik SSL">
+<!ENTITY object.usessl.help     "Of er SSL/TLS gebruikt moet worden tijdens het verbinden.">
+
+<!ENTITY object.add.label       "Toevoegen">
+<!ENTITY object.add.hint        "Voeg een netwerk of server toe">
+<!ENTITY object.add.accesskey   "T">
+
+<!ENTITY object.del.label       "Verwijderen">
+<!ENTITY object.del.hint        "Verwijder huidig netwerk of server">
+<!ENTITY object.del.accesskey   "V">

--- a/locales/nl-BE/chrome/pref-irc.dtd
+++ b/locales/nl-BE/chrome/pref-irc.dtd
@@ -1,0 +1,12 @@
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+
+<!ENTITY pref-irc.window.title "Ambassador">
+
+<!ENTITY pref-irc.open.title     "Ambassador's voorkeuren">
+<!ENTITY pref-irc.open.desc      "Ambassador's voorkeuren zijn te uitgebreid om in dit venster te tonen. Daarom kan je het voorkeurenvenster vanaf hier openen.">
+<!ENTITY pref-irc.open.label     "Open Ambassador's voorkeuren">
+<!ENTITY pref-irc.open.accesskey "O">
+<!ENTITY startup.chat.label "Ambassador">
+<!ENTITY startup.chat.accesskey "Z">

--- a/locales/nl-BE/chrome/security-info.dtd
+++ b/locales/nl-BE/chrome/security-info.dtd
@@ -1,0 +1,15 @@
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+
+<!ENTITY window.title                   "Beveiligingsinfo">
+
+<!ENTITY security.details               "Details van de SSL-verbinding">
+<!ENTITY security.hostname.label        "Host:">
+<!ENTITY security.status.label          "Status:">
+<!ENTITY security.cipher.label          "Versleutelingsalgoritme:">
+<!ENTITY security.keysize.label         "Sleutelgrootte:">
+<!ENTITY security.protocol.label        "Protocol:">
+
+<!ENTITY security.certView.label        "Bekijk certificaat">
+<!ENTITY security.certView.accesskey    "B">

--- a/locales/nl-BE/defines.inc
+++ b/locales/nl-BE/defines.inc
@@ -1,0 +1,14 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#filter emptyLines
+
+#define MOZ_LANGPACK_CREATOR Smile4ever
+
+#define MOZ_LANGPACK_HOMEPAGE https://github.com/Ascrod/ambassador/
+
+# If non-English locales wish to credit multiple contributors, uncomment this
+# variable definition and use the format specified.
+# #define MOZ_LANGPACK_CONTRIBUTORS <em:contributor>Joe Solon</em:contributor> <em:contributor>Suzy Solon</em:contributor>
+
+#unfilter emptyLines

--- a/locales/nl-BE/installer/custom.properties
+++ b/locales/nl-BE/installer/custom.properties
@@ -1,0 +1,81 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+# LOCALIZATION NOTE:
+
+# This file must be saved as UTF8
+
+# Accesskeys are defined by prefixing the letter that is to be used for the
+# accesskey with an ampersand (e.g. &).
+
+# Do not replace $BrandShortName, $BrandFullName, or $BrandFullNameDA with a
+# custom string and always use the same one as used by the en-US files.
+# $BrandFullNameDA allows the string to contain an ampersand (e.g. DA stands
+# for double ampersand) and prevents the letter following the ampersand from
+# being used as an accesskey.
+
+# You can use \n to create a newline in the string but only when the string
+# from en-US contains a \n.
+
+REG_APP_DESC=$BrandShortName is a clean, easy to use and highly extensible Internet Relay Chat (IRC) client, built on the Unified XUL Platform, which provides all the usual features: multiple servers, a built-in list of standard networks, easy searching and sorting of available channels, logging, and DCC chat and file transfers, plus easy customization with JavaScript plug-ins and CSS styling.
+CONTEXT_OPTIONS=$BrandShortName &Options
+CONTEXT_SAFE_MODE=$BrandShortName &Safe Mode
+OPTIONS_PAGE_TITLE=Setup Type
+OPTIONS_PAGE_SUBTITLE=Choose setup options
+SHORTCUTS_PAGE_TITLE=Set Up Shortcuts
+SHORTCUTS_PAGE_SUBTITLE=Create Program Icons
+SUMMARY_PAGE_TITLE=Summary
+SUMMARY_PAGE_SUBTITLE=Ready to start installing $BrandShortName
+SUMMARY_INSTALLED_TO=$BrandShortName will be installed to the following location:
+SUMMARY_REBOOT_REQUIRED_INSTALL=A restart of your computer may be required to complete the installation.
+SUMMARY_REBOOT_REQUIRED_UNINSTALL=A restart of your computer may be required to complete the uninstall.
+SUMMARY_TAKE_DEFAULTS=U&se $BrandShortName as my default IRC client
+SUMMARY_INSTALL_CLICK=Click Install to continue.
+SUMMARY_UPGRADE_CLICK=Click Upgrade to continue.
+SURVEY_TEXT=&Tell us what you thought of $BrandShortName
+LAUNCH_TEXT=&Launch $BrandShortName now
+CREATE_ICONS_DESC=Create icons for $BrandShortName:
+ICONS_DESKTOP=On my &Desktop
+ICONS_STARTMENU=In my &Start Menu Programs folder
+ICONS_QUICKLAUNCH=In my &Quick Launch bar
+WARN_MANUALLY_CLOSE_APP_INSTALL=$BrandShortName must be closed to proceed with the installation.\n\nPlease close $BrandShortName to continue.
+WARN_MANUALLY_CLOSE_APP_UNINSTALL=$BrandShortName must be closed to proceed with the uninstall.\n\nPlease close $BrandShortName to continue.
+WARN_MANUALLY_CLOSE_APP_LAUNCH=$BrandShortName is already running.\n\nPlease close $BrandShortName prior to launching the version you have just installed.
+WARN_WRITE_ACCESS=You don't have access to write to the installation directory.\n\nClick OK to select a different directory.
+WARN_DISK_SPACE=You don't have sufficient disk space to install to this location.\n\nClick OK to select a different location.
+WARN_MIN_SUPPORTED_OSVER_MSG=Sorry, $BrandShortName can't be installed. This version of $BrandShortName requires ${MinSupportedVer} or newer. Please click the OK button for additional information.
+WARN_MIN_SUPPORTED_CPU_MSG=Sorry, $BrandShortName can't be installed. This version of $BrandShortName requires a processor with ${MinSupportedCPU} support. Please click the OK button for additional information.
+WARN_MIN_SUPPORTED_OSVER_CPU_MSG=Sorry, $BrandShortName can't be installed. This version of $BrandShortName requires ${MinSupportedVer} or newer and a processor with ${MinSupportedCPU} support. Please click the OK button for additional information.
+WARN_RESTART_REQUIRED_UNINSTALL=Your computer must be restarted to complete a previous uninstall of $BrandShortName. Do you want to reboot now?
+WARN_RESTART_REQUIRED_UPGRADE=Your computer must be restarted to complete a previous upgrade of $BrandShortName. Do you want to reboot now?
+ERROR_CREATE_DIRECTORY_PREFIX=Error creating directory:
+ERROR_CREATE_DIRECTORY_SUFFIX=Click Cancel to stop the installation or\nRetry to try again.
+
+UN_CONFIRM_PAGE_TITLE=Uninstall $BrandFullName
+UN_CONFIRM_PAGE_SUBTITLE=Remove $BrandFullName from your computer.
+UN_CONFIRM_UNINSTALLED_FROM=$BrandShortName will be uninstalled from the following location:
+UN_CONFIRM_CLICK=Click Uninstall to continue.
+
+BANNER_CHECK_EXISTING=Checking existing installation…
+
+STATUS_INSTALL_APP=Installing $BrandShortName…
+STATUS_INSTALL_LANG=Installing Language Files (${AB_CD})…
+STATUS_UNINSTALL_MAIN=Uninstalling $BrandShortName…
+STATUS_CLEANUP=A Little Housekeeping…
+
+# _DESC strings support approximately 65 characters per line.
+# One line
+OPTIONS_SUMMARY=Choose the type of setup you prefer, then click Next.
+# One line
+OPTION_STANDARD_DESC=$BrandShortName will be installed with the most common options.
+OPTION_STANDARD_RADIO=&Standard
+# Two lines
+OPTION_CUSTOM_DESC=You may choose individual options to be installed. Recommended for experienced users.
+OPTION_CUSTOM_RADIO=&Custom
+
+# LOCALIZATION NOTE:
+# The following text replaces the Install button text on the summary page.
+# Verify that the access key for InstallBtn (in override.properties) and
+# UPGRADE_BUTTON is not already used by SUMMARY_TAKE_DEFAULTS.
+UPGRADE_BUTTON=&Upgrade

--- a/locales/nl-BE/installer/mui.properties
+++ b/locales/nl-BE/installer/mui.properties
@@ -1,0 +1,61 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+# To make the l10n tinderboxen see changes to this file you can change a value
+# name by adding - to the end of the name followed by chars (e.g. Branding-2).
+
+# LOCALIZATION NOTE:
+
+# This file must be saved as UTF8
+
+# Accesskeys are defined by prefixing the letter that is to be used for the
+# accesskey with an ampersand (e.g. &).
+
+# Do not replace $BrandShortName, $BrandFullName, or $BrandFullNameDA with a
+# custom string and always use the same one as used by the en-US files.
+# $BrandFullNameDA allows the string to contain an ampersand (e.g. DA stands
+# for double ampersand) and prevents the letter following the ampersand from
+# being used as an accesskey.
+
+# You can use \n to create a newline in the string but only when the string
+# from en-US contains a \n.
+
+MUI_TEXT_WELCOME_INFO_TITLE=Welcome to the $BrandFullNameDA Setup Wizard
+MUI_TEXT_WELCOME_INFO_TEXT=This wizard will guide you through the installation of $BrandFullNameDA.\n\nIt is recommended that you close all other applications before starting Setup. This will make it possible to update relevant system files without having to reboot your computer.\n\n$_CLICK
+MUI_TEXT_COMPONENTS_TITLE=Choose Components
+MUI_TEXT_COMPONENTS_SUBTITLE=Choose which features of $BrandFullNameDA you want to install.
+MUI_INNERTEXT_COMPONENTS_DESCRIPTION_TITLE=Description
+MUI_INNERTEXT_COMPONENTS_DESCRIPTION_INFO=Position your mouse over a component to see its description.
+MUI_TEXT_DIRECTORY_TITLE=Choose Install Location
+MUI_TEXT_DIRECTORY_SUBTITLE=Choose the folder in which to install $BrandFullNameDA.
+MUI_TEXT_INSTALLING_TITLE=Installing
+MUI_TEXT_INSTALLING_SUBTITLE=Please wait while $BrandFullNameDA is being installed.
+MUI_TEXT_FINISH_TITLE=Installation Complete
+MUI_TEXT_FINISH_SUBTITLE=Setup was completed successfully.
+MUI_TEXT_ABORT_TITLE=Installation Aborted
+MUI_TEXT_ABORT_SUBTITLE=Setup was not completed successfully.
+MUI_BUTTONTEXT_FINISH=&Finish
+MUI_TEXT_FINISH_INFO_TITLE=Completing the $BrandFullNameDA Setup Wizard
+MUI_TEXT_FINISH_INFO_TEXT=$BrandFullNameDA has been installed on your computer.\n\nClick Finish to close this wizard.
+MUI_TEXT_FINISH_INFO_REBOOT=Your computer must be restarted in order to complete the installation of $BrandFullNameDA. Do you want to reboot now?
+MUI_TEXT_FINISH_REBOOTNOW=Reboot now
+MUI_TEXT_FINISH_REBOOTLATER=I want to manually reboot later
+MUI_TEXT_STARTMENU_TITLE=Choose Start Menu Folder
+MUI_TEXT_STARTMENU_SUBTITLE=Choose a Start Menu folder for the $BrandFullNameDA shortcuts.
+MUI_INNERTEXT_STARTMENU_TOP=Select the Start Menu folder in which you would like to create the program's shortcuts. You can also enter a name to create a new folder.
+MUI_TEXT_ABORTWARNING=Are you sure you want to quit $BrandFullName Setup?
+MUI_UNTEXT_WELCOME_INFO_TITLE=Welcome to the $BrandFullNameDA Uninstall Wizard
+MUI_UNTEXT_WELCOME_INFO_TEXT=This wizard will guide you through the uninstallation of $BrandFullNameDA.\n\nBefore starting the uninstallation, make sure $BrandFullNameDA is not running.\n\n$_CLICK
+MUI_UNTEXT_CONFIRM_TITLE=Uninstall $BrandFullNameDA
+MUI_UNTEXT_CONFIRM_SUBTITLE=Remove $BrandFullNameDA from your computer.
+MUI_UNTEXT_UNINSTALLING_TITLE=Uninstalling
+MUI_UNTEXT_UNINSTALLING_SUBTITLE=Please wait while $BrandFullNameDA is being uninstalled.
+MUI_UNTEXT_FINISH_TITLE=Uninstallation Complete
+MUI_UNTEXT_FINISH_SUBTITLE=Uninstall was completed successfully.
+MUI_UNTEXT_ABORT_TITLE=Uninstallation Aborted
+MUI_UNTEXT_ABORT_SUBTITLE=Uninstall was not completed successfully.
+MUI_UNTEXT_FINISH_INFO_TITLE=Completing the $BrandFullNameDA Uninstall Wizard
+MUI_UNTEXT_FINISH_INFO_TEXT=$BrandFullNameDA has been uninstalled from your computer.\n\nClick Finish to close this wizard.
+MUI_UNTEXT_FINISH_INFO_REBOOT=Your computer must be restarted in order to complete the uninstallation of $BrandFullNameDA. Do you want to reboot now?
+MUI_UNTEXT_ABORTWARNING=Are you sure you want to quit $BrandFullName Uninstall?

--- a/locales/nl-BE/installer/nsisstrings.properties
+++ b/locales/nl-BE/installer/nsisstrings.properties
@@ -1,0 +1,67 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+# LOCALIZATION NOTE:
+
+# This file must be saved as UTF8
+
+# Accesskeys are defined by prefixing the letter that is to be used for the
+# accesskey with an ampersand (e.g. &).
+
+# Do not replace $BrandShortName, $BrandFullName, or $BrandFullNameDA with a
+# custom string and always use the same one as used by the en-US files.
+# $BrandFullNameDA allows the string to contain an ampersand (e.g. DA stands
+# for double ampersand) and prevents the letter following the ampersand from
+# being used as an accesskey.
+
+# You can use \n to create a newline in the string but only when the string
+# from en-US contains a \n.
+
+WIN_CAPTION=$BrandShortName Setup
+
+INTRO_BLURB1=Thanks for choosing $BrandFullName, the browser that chooses you above everything else.
+INSTALL_BLURB1=You're about to enjoy the very latest in speed, flexibility and security so you're always in control.
+INSTALL_BLURB2=That's because $BrandShortName is made by a non-profit to make browsing and the Web better for you.
+INSTALL_BLURB3=You're also joining a global community of users, contributors and developers working to make the best browser in the world.
+
+WARN_MIN_SUPPORTED_OSVER_MSG=Sorry, $BrandShortName can't be installed. This version of $BrandShortName requires ${MinSupportedVer} or newer. Please click the OK button for additional information.
+WARN_MIN_SUPPORTED_CPU_MSG=Sorry, $BrandShortName can't be installed. This version of $BrandShortName requires a processor with ${MinSupportedCPU} support. Please click the OK button for additional information.
+WARN_MIN_SUPPORTED_OSVER_CPU_MSG=Sorry, $BrandShortName can't be installed. This version of $BrandShortName requires ${MinSupportedVer} or newer and a processor with ${MinSupportedCPU} support. Please click the OK button for additional information.
+WARN_WRITE_ACCESS=You don't have access to write to the installation directory.\n\nClick OK to select a different directory.
+WARN_DISK_SPACE=You don't have sufficient disk space to install to this location.\n\nClick OK to select a different location.
+WARN_ROOT_INSTALL=Unable to install to the root of your disk.\n\nClick OK to select a different location.
+WARN_MANUALLY_CLOSE_APP_LAUNCH=$BrandShortName is already running.\n\nPlease close $BrandShortName prior to launching the version you have just installed.
+
+ERROR_DOWNLOAD=Your download was interrupted.\n\nPlease click the OK button to continue.
+
+INSTALL_BUTTON=&Install
+UPGRADE_BUTTON=&Upgrade
+CANCEL_BUTTON=Cancel
+OPTIONS_BUTTON=&Options
+
+MAKE_DEFAULT=&Make $BrandShortName my default IRC client
+CREATE_SHORTCUTS=Create Shortcuts for $BrandShortName:
+ADD_SC_TASKBAR=On my &Task bar
+ADD_SC_QUICKLAUNCHBAR=On my &Quick Launch bar
+ADD_CheckboxShortcutInStartMenu=In my &Start Menu Programs Folder
+ADD_CheckboxShortcutOnDesktop=On my &Desktop
+SPACE_REQUIRED=Space Required:
+SPACE_AVAILABLE=Space Available:
+ONE_MOMENT_INSTALL=One moment, $BrandShortName will launch as soon as the install is complete…
+ONE_MOMENT_UPGRADE=One moment, $BrandShortName will launch as soon as the upgrade is complete…
+INSTALL_MAINT_SERVICE=&Install the $BrandShortName background update service
+SEND_PING=S&end information about this installation to Mozilla
+BROWSE_BUTTON=B&rowse…
+DEST_FOLDER=Destination Folder
+
+DOWNLOADING_LABEL=Downloading $BrandShortName…
+INSTALLING_LABEL=Installing $BrandShortName…
+UPGRADING_LABEL=Upgrading $BrandShortName…
+
+SELECT_FOLDER_TEXT=Select the folder to install $BrandShortName in.
+
+BYTE=B
+KILO=K
+MEGA=M
+GIGA=G

--- a/locales/nl-BE/installer/override.properties
+++ b/locales/nl-BE/installer/override.properties
@@ -1,0 +1,86 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+# LOCALIZATION NOTE:
+
+# This file must be saved as UTF8
+
+# Accesskeys are defined by prefixing the letter that is to be used for the
+# accesskey with an ampersand (e.g. &).
+
+# Do not replace $BrandShortName, $BrandFullName, or $BrandFullNameDA with a
+# custom string and always use the same one as used by the en-US files.
+# $BrandFullNameDA allows the string to contain an ampersand (e.g. DA stands
+# for double ampersand) and prevents the letter following the ampersand from
+# being used as an accesskey.
+
+# You can use \n to create a newline in the string but only when the string
+# from en-US contains a \n.
+
+# Strings that require a space at the end should be enclosed with double
+# quotes and the double quotes will be removed. To add quotes to the beginning
+# and end of a strong enclose the add and additional double quote to the
+# beginning and end of the string (e.g. ""This will include quotes"").
+
+SetupCaption=$BrandFullName Setup
+UninstallCaption=$BrandFullName Uninstall
+BackBtn=< &Back
+NextBtn=&Next >
+AcceptBtn=I &accept the terms in the License Agreement
+DontAcceptBtn=I &do not accept the terms in the License Agreement
+InstallBtn=&Install
+UninstallBtn=&Uninstall
+CancelBtn=Cancel
+CloseBtn=&Close
+BrowseBtn=B&rowse…
+ShowDetailsBtn=Show &details
+ClickNext=Click Next to continue.
+ClickInstall=Click Install to start the installation.
+ClickUninstall=Click Uninstall to start the uninstallation.
+Completed=Completed
+LicenseTextRB=Please review the license agreement before installing $BrandFullNameDA. If you accept all terms of the agreement, select the first option below. $_CLICK
+ComponentsText=Check the components you want to install and uncheck the components you don't want to install. $_CLICK
+ComponentsSubText2_NoInstTypes=Select components to install:
+DirText=Setup will install $BrandFullNameDA in the following folder. To install in a different folder, click Browse and select another folder. $_CLICK
+DirSubText=Destination Folder
+DirBrowseText=Select the folder to install $BrandFullNameDA in:
+SpaceAvailable="Space available: "
+SpaceRequired="Space required: "
+UninstallingText=$BrandFullNameDA will be uninstalled from the following folder. $_CLICK
+UninstallingSubText=Uninstalling from:
+FileError=Error opening file for writing: \r\n\r\n$0\r\n\r\nClick Abort to stop the installation,\r\nRetry to try again, or\r\nIgnore to skip this file.
+FileError_NoIgnore=Error opening file for writing: \r\n\r\n$0\r\n\r\nClick Retry to try again, or\r\nCancel to stop the installation.
+CantWrite="Can't write: "
+CopyFailed=Copy failed
+CopyTo="Copy to "
+Registering="Registering: "
+Unregistering="Unregistering: "
+SymbolNotFound="Could not find symbol: "
+CouldNotLoad="Could not load: "
+CreateFolder="Create folder: "
+CreateShortcut="Create shortcut: "
+CreatedUninstaller="Created uninstaller: "
+Delete="Delete file: "
+DeleteOnReboot="Delete on reboot: "
+ErrorCreatingShortcut="Error creating shortcut: "
+ErrorCreating="Error creating: "
+ErrorDecompressing=Error decompressing data! Corrupted installer?
+ErrorRegistering=Error registering DLL
+ExecShell="ExecShell: "
+Exec="Execute: "
+Extract="Extract: "
+ErrorWriting="Extract: error writing to file "
+InvalidOpcode=Installer corrupted: invalid opcode
+NoOLE="No OLE for: "
+OutputFolder="Output folder: "
+RemoveFolder="Remove folder: "
+RenameOnReboot="Rename on reboot: "
+Rename="Rename: "
+Skipped="Skipped: "
+CopyDetails=Copy Details To Clipboard
+LogInstall=Log install process
+Byte=B
+Kilo=K
+Mega=M
+Giga=G


### PR DESCRIPTION
Hi.

I was unsure about
```
<!ENTITY ForeBack.label              "xx=Fore yy=Back">
```
so I left it like I found it.

Also, I didn't translate the "installer" part. Just the files in locales/nl-BE/chrome.

Also, I added the locale to the list locales/all-locales. I wonder what the other locales are doing there, since I don't see them. Should they be removed? Or should they be imported from ChatZilla?

Thank you for looking at this.